### PR TITLE
Remove sassc gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem "bootsnap", require: false
 
 # Use Sass to process CSS
-gem "sassc-rails"
+# gem "sassc-rails"
 
 # User authentication
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,6 @@ GEM
       railties (>= 5.0.0)
     faker (2.19.0)
       i18n (>= 1.6, < 2)
-    ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
     govuk-components (3.0.1)
@@ -227,14 +226,6 @@ GEM
     rspec-support (3.10.3)
     ruby_parser (3.18.1)
       sexp_processor (~> 4.16)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     sexp_processor (4.16.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -292,7 +283,6 @@ DEPENDENCIES
   puma (~> 5.6)
   rails (~> 7.0.1)
   rspec-rails
-  sassc-rails
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress CSS using a preprocessor.
-  config.assets.css_compressor = :sass
+  # config.assets.css_compressor = :sass
 
   # Remove sass compression errors.
   # See https://github.com/alphagov/govuk-frontend/issues/1350#issuecomment-493129270


### PR DESCRIPTION
Remove the sass gem - caused deployment issues.  SASS compilation is now handled by `cssbundling-rails` gem.

