### PR TITLE
ER-57: Add module items with matching new data structure

### DIFF
--- a/app/controllers/content_pages_controller.rb
+++ b/app/controllers/content_pages_controller.rb
@@ -1,0 +1,21 @@
+class ContentPagesController < ApplicationController
+  def show
+    @model = module_item.model
+
+    if @model.is_a?(Questionnaire)
+      redirect_to @model
+    else
+      render module_item.type
+    end
+  end
+
+  private
+
+  def module_item
+    @module_item ||= ModuleItem.find_by(training_module: training_module, id: params[:id])
+  end
+
+  def training_module
+    params[:training_module_id]
+  end
+end

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -7,8 +7,7 @@ class QuestionnairesController < ApplicationController
     questionnaire.errors.clear
     update_questionnaire
     if results.values.all?(true)
-      # TODO: redirect to next step
-      render :show, status: :unprocessable_entity # status set to force page reload
+      redirect_to training_module_content_page_path(questionnaire.training_module, next_module_item)
     else
       generate_error_messages
       render :show, status: :unprocessable_entity
@@ -19,6 +18,11 @@ class QuestionnairesController < ApplicationController
 
   def questionnaire
     @questionnaire ||= Questionnaire.find_by!(name: params[:id])
+  end
+
+  def next_module_item
+    current_module_item = ModuleItem.find_by(training_module: questionnaire.training_module, id: questionnaire.name)
+    current_module_item.next_item
   end
 
   def update_questionnaire

--- a/app/models/content_page.rb
+++ b/app/models/content_page.rb
@@ -1,0 +1,27 @@
+class ContentPage
+  include ActiveModel::Validations
+  include ActiveModel::Model
+
+  attr_accessor :id, :type, :training_module
+
+  validates :heading, :body, presence: true
+
+  def i18n_scope
+    [:modules, training_module, id]
+  end
+
+  def heading
+    translate(:heading)
+  end
+
+  def body
+    translate(:body)
+  end
+
+  def translate(label)
+    # Suppress translation returning "translation missing" message so validation for presence works
+    return unless I18n.exists?([i18n_scope, label])
+    
+    I18n.t(label, scope: i18n_scope)
+  end
+end

--- a/app/models/module_item.rb
+++ b/app/models/module_item.rb
@@ -1,0 +1,44 @@
+class ModuleItem < YamlBase
+  MODELS = {
+    module_intro: ContentPage,
+    sub_module_intro: ContentPage,
+    text_page: ContentPage,
+    formative_assessment: Questionnaire
+  }
+
+  extend YamlFolder
+  set_folder "modules"
+
+  # Override ActiveYaml::Base load_file method to get data nested within file and use parent keys to populate attributes
+  def self.load_file
+    data = raw_data.map do |training_module, items|
+      items.map do |id, values|
+        values.merge(id: id.to_s, training_module: training_module)
+      end
+    end
+    data.flatten! # Using flatten! as more memory efficient.
+    data
+  end
+
+  def model
+    klass = MODELS[type.to_sym]
+    if klass == Questionnaire
+      Questionnaire.find_by(name: id)
+    else
+      klass.new(attributes)
+    end
+  end
+  delegate :valid?, to: :model
+
+  def next_item
+    self.class.all.to_a[place_in_flow + 1]
+  end
+
+  def place_in_flow
+    self.class.all.to_a.index(self)
+  end
+  
+  def to_param
+    id
+  end
+end

--- a/app/views/content_pages/module_intro.html.haml
+++ b/app/views/content_pages/module_intro.html.haml
@@ -1,0 +1,4 @@
+%h1=@model.heading
+%h2 This is a module intro
+%p=@model.body
+%p=link_to "Next", training_module_content_page_path(@module_item.training_module, @module_item.next_item)

--- a/app/views/content_pages/sub_module_intro.html.haml
+++ b/app/views/content_pages/sub_module_intro.html.haml
@@ -1,0 +1,4 @@
+%h1=@model.heading
+%h2 This is a sub module intro
+%p=@model.body
+%p=link_to "Next", training_module_content_page_path(@module_item.training_module, @module_item.next_item)

--- a/app/views/content_pages/text_page.html.haml
+++ b/app/views/content_pages/text_page.html.haml
@@ -1,0 +1,4 @@
+%h1=@model.heading
+%h2 This is a text page
+%p=@model.body
+%p=link_to("Next", training_module_content_page_path(@module_item.training_module, @module_item.next_item)) if @module_item.next_item

--- a/config/locales/modules.yml
+++ b/config/locales/modules.yml
@@ -1,0 +1,37 @@
+---
+en:
+  modules:
+    test:
+      test:
+        heading: A test
+      basic:
+        heading: A text page
+        body: Some text
+    one:
+      1:
+        heading: Module 1 - Foo
+        body: This is important and here is some text
+      1-1:
+        heading: Foo Part One
+        body: In this submodule we'll discuss some stuff
+      1-1-1:
+        heading: Stuff is cool
+        body: Oh yes!
+      1-1-2:
+        heading: Stuff everywhere
+        body: It's all around us
+      1-1-3:
+        heading: We like stuff
+        body: Hurrah!
+      1-1-4:
+        heading: What did you learn about stuff
+      1-2-1:
+        heading: Not for everyone
+        body: Some people don't like stuff
+      1-2-2:
+        heading: What sort of people don't like stuff
+      1-2-3:
+        heading: How to avoid the stuff haters
+        body: Hide behind stuff
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
         get :recap
       end
     end
+    resources :content_pages, only: [:show]
   end
   resources :extra_registrations, only: [:index, :edit, :update]
   resources :questionnaires, only: [:show, :update]

--- a/data/modules/one.yml
+++ b/data/modules/one.yml
@@ -1,0 +1,21 @@
+---
+one:
+  1:
+    type: module_intro
+  1-1:
+    type: sub_module_intro
+  1-1-1:
+    type: text_page
+  1-1-2:
+    type: text_page
+  1-1-3:
+    type: text_page
+  1-1-4:
+    type: formative_assessment
+  1-2-1:
+    type: text_page
+  1-2-2:
+    type: formative_assessment
+  1-2-3:
+    type: text_page
+

--- a/data/modules/test.yml
+++ b/data/modules/test.yml
@@ -1,0 +1,6 @@
+---
+test:
+  test:
+    type: formative_assessment
+  basic:
+    type: text_page

--- a/data/questionnaires/one.yml
+++ b/data/questionnaires/one.yml
@@ -1,0 +1,30 @@
+---
+1-1-4:
+  heading: A Question of Stuff
+  content: A simple question
+  training_module: one
+  questions:
+    like_stuff:
+      multi_select: false
+      label: Do you like stuff
+      answers:
+        "yes": "Yes" # Set as string as YAML parses yes as true
+        "no": "No" # Set as string as YAML parses no as false
+      correct_answers:
+        - "yes"
+1-2-2:
+  heading: What sort of people don't like stuff
+  content: So who?
+  training_module: one
+  questions:
+    who_likes_stuff:
+      multi_select: true
+      label: Who likes stuff
+      answers:
+        stuffy_people: Stuffy people
+        everybody: Everybody
+        nobody: Nobody
+        stuffers: People who do the stuffing
+      correct_answers:
+        - stuffy_people
+        - stuffers

--- a/data/questionnaires/test.yml
+++ b/data/questionnaires/test.yml
@@ -1,7 +1,8 @@
 ---
-simple:
+test:
   heading: A simple questionnaire
   content: It just has some questions and answers
+  training_module: test
   questions:
     one_from_many:
       multi_select: false

--- a/spec/models/content_page_spec.rb
+++ b/spec/models/content_page_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe ContentPage, type: :model do
+  let(:content) { YAML.load_file(Rails.root.join("config/locales/modules.yml")).dig("en", "modules", "test") }
+  let(:content_page) { ContentPage.new(id: :basic, training_module: :test, type: :text_page) }
+
+  describe "#heading" do
+    it "returns the heading data from the content file" do
+      expect(content_page.heading).to eq(content.dig(content_page.id.to_s, 'heading'))
+    end
+  end
+
+  describe "#body" do
+    it "returns the body data from the content file" do
+      expect(content_page.body).to eq(content.dig(content_page.id.to_s, 'body'))
+    end
+  end
+end

--- a/spec/models/module_item_spec.rb
+++ b/spec/models/module_item_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe ModuleItem, type: :model do
+  let(:yaml_data) { data_from_file("modules/test.yml") }
+  let(:module_item) { described_class.where(training_module: :test).first }
+
+  it "loads data from file" do
+    expect(module_item.type).to eq(yaml_data.dig('test', module_item.id, 'type'))
+  end
+
+  describe "#next_item" do
+    let(:next_module_item) { described_class.where(training_module: :test).to_a[1] }
+    
+    it "returns the next module item" do
+      expect(module_item.next_item).to eq(next_module_item)
+    end
+  end
+
+  describe "#model" do
+    let(:module_item) { described_class.find_by(training_module: :test, type: :text_page) }
+    let(:model) { module_item.model }
+
+    it "returns the match model object" do
+      expect(model).to be_a(ContentPage)
+    end
+
+    it "includes module item data" do
+      expect(model.type).to eq(module_item.type)
+      expect(model.id).to eq(module_item.id)
+    end
+
+    context "when model is a questionniare" do
+      let(:module_item) { described_class.find_by(training_module: :test, type: :formative_assessment) }
+
+      it "returns a questionnaire" do
+        expect(model).to be_a(Questionnaire)
+      end
+
+      it "matches the module item" do
+        expect(model.name).to eq(module_item.id)
+      end
+    end
+  end
+end

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Questionnaire, type: :model do
-  let(:yaml_data) { data_from_file("questionnaires/simple.yml") }
-  let(:questionnaire) { described_class.find_by(name: :simple) }
+  let(:yaml_data) { data_from_file("questionnaires/test.yml") }
+  let(:questionnaire) { described_class.find_by(name: :test) }
 
   it "loads basic method" do
-    expect(questionnaire.heading).to eq(yaml_data.dig('simple', 'heading'))
-    expect(questionnaire.content).to eq(yaml_data.dig('simple', 'content'))
+    expect(questionnaire.heading).to eq(yaml_data.dig('test', 'heading'))
+    expect(questionnaire.content).to eq(yaml_data.dig('test', 'content'))
   end
 
   it "loads questions as a hash" do
@@ -14,13 +14,13 @@ RSpec.describe Questionnaire, type: :model do
   end
 
   it "loads answers within questions with symbolized keys" do
-    answers = yaml_data.dig('simple', 'questions', 'one_from_many', 'answers')
+    answers = yaml_data.dig('test', 'questions', 'one_from_many', 'answers')
     answers.symbolize_keys!
     expect(questionnaire.questions.dig(:one_from_many, :answers)).to eq(answers)
   end
 
   it "loads correct answers within questions" do
-    correct_answers = yaml_data.dig('simple', 'questions', 'one_from_many', 'correct_answers')
+    correct_answers = yaml_data.dig('test', 'questions', 'one_from_many', 'correct_answers')
     expect(questionnaire.questions.dig(:one_from_many, :correct_answers)).to eq(correct_answers)
   end
 end

--- a/spec/requests/content_pages_spec.rb
+++ b/spec/requests/content_pages_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe "ContentPages", type: :request do
+
+  describe "GET /modules/:training_module_id/content_pages/:id" do
+    let(:module_item) { ModuleItem.find_by(training_module: :test, type: :text_page) }
+
+    it "renders a template successfully" do
+      get training_module_content_page_path(:test, module_item.id)
+      expect(response).to have_http_status(:success)
+    end
+
+    context "when module item is a questionnaire" do
+      let(:module_item) { ModuleItem.find_by(training_module: :test, type: :formative_assessment) }
+
+      it "redirects to questionnaire controller" do
+        get training_module_content_page_path(:test, module_item.id)
+        expect(response).to redirect_to(questionnaire_path(module_item.model))
+      end
+    end
+  end
+end

--- a/spec/requests/questionnaires_spec.rb
+++ b/spec/requests/questionnaires_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Questionnaires", type: :request do
-  let(:questionnaire) { Questionnaire.find_by(name: :simple) }
+  let(:questionnaire) { Questionnaire.find_by(name: :test) }
 
   describe "GET /questionnaires/:id" do
     it "returns http success" do
@@ -31,12 +31,12 @@ RSpec.describe "Questionnaires", type: :request do
     let(:incorrect_answers) do
       questionnaire.questions.transform_values { |_a| :foo }
     end
+
+    let(:module_item) { ModuleItem.find_by(training_module: questionnaire.training_module, id: questionnaire.name) }
     
-    # This behaviour should change to redirecting to next page
     it "does something without error" do
       patch questionnaire_path(questionnaire), params: { questionnaire: correct_answers }
-      expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).not_to include("class='errors'")
+      expect(response).to redirect_to(training_module_content_page_path(module_item.training_module, module_item.next_item))
     end
 
     context "with incorrect answers" do


### PR DESCRIPTION
This PR introduces a way of presenting the page data via YAML files.

If this code is run locally, a flow can be followed through a mock training module from:
- start: http://localhost:3000/modules/one/content_pages/1
- to: http://localhost:3000/modules/one/content_pages/1-2-3

This mock flow includes passage through two questionnaires.

## YAML data
There are three YAML file types, Data, Cotent and Questionnaires. Note that the data for each type is spread across multiple files.

### Data
Stored in `/data/modules`

These files define the page flow and data types (which is used to define how the content is presented).
Flow is controlled by position within the file; flow progresses from top to bottom through the file

### Content
Stored in `/config/locales/modules.yml`

Locales were used so as to utilize I18n functionality, but this was not as useful as I was hoping, and moving to another folder (for example `/content` or `/data/content`) may be a better option.

The content defines what will be displayed on the page. Separating it from data should help minimize the file size, and avoid breaking data structures when updating content.

### Questionnaires
Stored in `/data/questionnaires`

Questionnaires have to behave differently to other content as the data needs to be presented as a form and user submission needs to be assess before moving to the next page. As a result, they have a different data structure and need to be handled differently.

## Models
There are also two model types:

### ModuleItem
This pulls data from the data yaml store. Its main role is to control flow. The array of module items returned by `ModuleItem.where(training_module: :module_name).to_a` effectively defines the flow through a particular training module.

### Content specific models
There are two content specific models at the moment: `Questionnaire` and `ContentPage`. I expect there will be more.

Having models that are specific to the content type provides a place where code relating to just that content type can be placed. For example, in `ContentPage` validation is present that can ensure that the content data matches set rules (to avoid bad data input when defining content.

Note that currently the `ContentPage` model is shared across many data types. This can be changed as requirements change. We may need a one-to-one model to data type relationship in the future.

## Controllers
There are two controllers:

### Content Pages
This displays content data for the current module item (except if the match model is a questionnaire, in which case the user is redirected to the questionnaire controller).

There are a set of view templates. Each matches a different module item type. It may make sense to move to a `show` template and have module item type specific partials (or other content objects) defined within that template to provide a place where content shared across pages (for example the "Next page" button) can be placed.

### Questionnaire
This controller handles the display and submission of questions. On successful completion of a questionnaire the user is redirected to the next module item.
