### PR TITLE
ER-1 Allow user to modify their profile

### DIFF
--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -1,4 +1,6 @@
 class QuestionnairesController < ApplicationController
+  before_action :authenticate_registered_user!
+
   def show
     questionnaire
   end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,0 +1,29 @@
+class UserController < ApplicationController
+  before_action :authenticate_registered_user!
+
+  def show
+    user
+  end
+
+  def edit
+    user
+  end
+
+  def update
+    if user.update(user_params)
+      redirect_to user_path, notice: "Profile updated"
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def user
+    @user ||= current_user
+  end
+
+  def user_params
+    params.require(:user).permit(:first_name, :last_name, :postcode, :ofsted_number)
+  end
+end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -26,6 +26,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
 
     set_personalisation(
       email_subject: 'Confirm account',
+      name: record.name,
       confirmation_url: confirmation_url(record, confirmation_token: token)
     )
     mail(to: record.email)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,8 @@ class User < ApplicationRecord
   # :lockable, :timeoutable, :trackable, :recoverable and :omniauthable
   devise :database_authenticatable, :registerable,
          :validatable, :rememberable, :confirmable
+
+  def name
+    [first_name, last_name].compact.join(" ")
+  end
 end

--- a/app/views/user/edit.html.haml
+++ b/app/views/user/edit.html.haml
@@ -1,0 +1,7 @@
+%h1 Edit your profile
+= form_for @user do |form|
+  %dl
+  - [:first_name, :last_name, :postcode, :ofsted_number].each do |field|
+    %dt= form.label field
+    %dd= form.text_field field
+  %p=form.submit

--- a/app/views/user/show.html.haml
+++ b/app/views/user/show.html.haml
@@ -1,0 +1,18 @@
+%h1 Your Profile
+%dl
+  %dt First name
+  %dd= @user.first_name
+
+  %dt Last name
+  %dd= @user.last_name
+
+  %dt Email address
+  %dd= @user.email
+
+  %dt Postcode
+  %dd= @user.postcode
+
+  %dt Ofsted Number
+  %dd= @user.ofsted_number
+
+%p= link_to "Edit", edit_user_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: { registrations: "registrations" }
   resources :extra_registrations, only: [:index, :edit, :update]
+  resource :user, only: [:show, :edit, :update], controller: :user
 
   resources :modules, only: [:index], as: :training_modules, controller: :training_modules do
     resources :content_pages, only: [:index, :show]

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -21,13 +21,11 @@ RSpec.describe "Authentication", type: :request do
       before { sign_in create(:user) }
 
       it "redirects to sign in page" do
-        pending("email confirmation enabled")
         get action_path
         expect(response).to redirect_to(new_user_session_path)
       end
 
       it "displays message that confirmation link email sent" do
-        pending("email confirmation enabled")
         get action_path
         follow_redirect!
         expect(response.body).to include("You have to confirm your email address")
@@ -74,13 +72,11 @@ RSpec.describe "Authentication", type: :request do
       before { sign_in create(:user) }
 
       it "redirects to sign in page" do
-        pending("email confirmation enabled")
         get action_path
         expect(response).to redirect_to(new_user_session_path)
       end
 
       it "displays message that confirmation link email sent" do
-        pending("email confirmation enabled")
         get action_path
         follow_redirect!
         expect(response.body).to include("You have to confirm your email address")

--- a/spec/requests/questionnaires_spec.rb
+++ b/spec/requests/questionnaires_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe "Questionnaires", type: :request do
   let(:questionnaire) { Questionnaire.find_by(name: :test, training_module: :test) }
 
+  before do
+    sign_in create(:user, :registered)
+  end
+
   describe "GET /questionnaires/:id" do
     it "returns http success" do
       get training_module_questionnaire_path(:test, questionnaire)

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe "User", type: :request do
+  let(:user) { create :user, :registered }
+
+  before { sign_in user }
+
+  describe "GET /user" do
+    it "renders page" do
+      get user_path
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /user/edit" do
+    it "renders page" do
+      get edit_user_path
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "patch /user" do
+    let(:first_name) { "Foo-Bar" }
+
+    subject { patch user_path, params: { user: { first_name: first_name } } }
+
+    it "updates the user" do
+      expect { subject }.to change(user.reload, :first_name).to(first_name)
+    end
+
+    it "redirects back to the show page" do
+      expect(subject).to redirect_to(user_path)
+    end
+  end
+end


### PR DESCRIPTION
Adds a controller to allow user to see their details and change them. The new pages are available at `/user`

Also
- update authentication spec to test confirmation options
- fixed notify issue where template requires `user.name` but method doesn't exist
- ensure users accessing questionnaires are logged in