### PR TITLE
ER-57 Add link to previous page within training module pages

### DIFF
--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -23,8 +23,7 @@ class QuestionnairesController < ApplicationController
   end
 
   def next_module_item
-    current_module_item = ModuleItem.find_by(training_module: training_module, name: questionnaire.name)
-    current_module_item.next_item
+    questionnaire.module_item.next_item
   end
 
   def update_questionnaire

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,4 +31,13 @@ module ApplicationHelper
       link_to "Finish", training_modules_path
     end
   end
+
+  def link_to_previous_module_item(module_item)
+    link = if module_item.previous_item
+      training_module_content_page_path(module_item.training_module, module_item.previous_item)
+    else
+      training_modules_path
+    end
+    link_to "Previous", link
+  end
 end

--- a/app/models/module_item.rb
+++ b/app/models/module_item.rb
@@ -34,6 +34,12 @@ class ModuleItem < YamlBase
     module_items_in_this_training_module[place_in_flow + 1]
   end
 
+  def previous_item
+    return if place_in_flow.zero?
+
+    module_items_in_this_training_module[place_in_flow - 1]
+  end
+
   def place_in_flow
     module_items_in_this_training_module.index(self)
   end

--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -23,6 +23,10 @@ class Questionnaire < YamlBase
     self[:questions]
   end
 
+  def module_item
+    @module_item ||= ModuleItem.find_by(training_module: training_module, name: name)
+  end
+
   def errors
     @errors ||= ActiveModel::Errors.new(self)
   end

--- a/app/views/content_pages/module_intro.html.haml
+++ b/app/views/content_pages/module_intro.html.haml
@@ -1,4 +1,6 @@
 %h1=@model.heading
 =image_tag(@model.image) if @model.image.present?
 %p=translate_markdown(@model.body)
-%p=link_to_next_module_item(@module_item)
+%p
+  =link_to_previous_module_item(@module_item)
+  =link_to_next_module_item(@module_item)

--- a/app/views/content_pages/sub_module_intro.html.haml
+++ b/app/views/content_pages/sub_module_intro.html.haml
@@ -1,4 +1,6 @@
 %h1=@model.heading
 %h2 This is a sub module intro
 %p=@model.body
-%p=link_to_next_module_item(@module_item)
+%p
+  =link_to_previous_module_item(@module_item)
+  =link_to_next_module_item(@module_item)

--- a/app/views/content_pages/text_page.html.haml
+++ b/app/views/content_pages/text_page.html.haml
@@ -1,4 +1,6 @@
 %h1=@model.heading
 %h2 This is a text page
 %p=@model.body
-%p=link_to_next_module_item(@module_item)
+%p
+  =link_to_previous_module_item(@module_item)
+  =link_to_next_module_item(@module_item)

--- a/app/views/questionnaires/show.html.haml
+++ b/app/views/questionnaires/show.html.haml
@@ -20,3 +20,4 @@
           = input.label
 
   = submit_tag "Submit"
+  %p= link_to_previous_module_item(@questionnaire.module_item)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -10,9 +10,26 @@ describe 'ApplicationHelper', type: :helper do
       expect(link).to include(training_module_content_page_path(module_item.training_module, last_module_item))
     end
 
-    context "when module items is last" do
+    context "when module item is last item" do
       it "returns a link to training modules root" do
         link = helper.link_to_next_module_item(module_item)
+        expect(link).to include(training_modules_path)
+      end
+    end
+  end
+
+  describe "#link_to_previous_module_item" do
+    let(:first_module_item) { ModuleItem.where(training_module: :test).to_a[0] }
+    let(:second_module_item) { ModuleItem.where(training_module: :test).to_a[1] }
+
+    it "returns a link to the previous page" do
+      link = helper.link_to_previous_module_item(second_module_item)
+      expect(link).to include(training_module_content_page_path(first_module_item.training_module, first_module_item))
+    end
+
+    context "when module item is first item" do
+      it "returns a link to training modules root" do
+        link = helper.link_to_previous_module_item(first_module_item)
         expect(link).to include(training_modules_path)
       end
     end

--- a/spec/models/module_item_spec.rb
+++ b/spec/models/module_item_spec.rb
@@ -15,11 +15,26 @@ RSpec.describe ModuleItem, type: :model do
       expect(module_item.next_item).to eq(next_module_item)
     end
 
-    context "when items is last item" do
+    context "when item is last item" do
       let(:last_module_item) { described_class.where(training_module: :test).last }
 
       it "returns nil" do
         expect(last_module_item.next_item).to be_nil
+      end
+    end
+  end
+
+  describe "#previous_item" do
+    let(:first_module_item) { module_item }
+    let(:second_module_item) { described_class.where(training_module: :test).to_a[1] }
+
+    it "returns the previous module item" do
+      expect(second_module_item.previous_item).to eq(first_module_item)
+    end
+
+    context "when item is first item" do
+      it "returns nil" do
+        expect(first_module_item.previous_item).to be_nil
       end
     end
   end

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -23,4 +23,9 @@ RSpec.describe Questionnaire, type: :model do
     correct_answers = yaml_data.dig('test', 'test', 'questions', 'one_from_many', 'correct_answers')
     expect(questionnaire.questions.dig(:one_from_many, :correct_answers)).to eq(correct_answers)
   end
+
+  it "is associated with matching module item" do
+    module_item = ModuleItem.find_by(training_module: :test, name: :test)
+    expect(questionnaire.module_item).to eq(module_item)
+  end
 end


### PR DESCRIPTION
Adds a "Previous" page link to training module pages

If the page is the first page within a training module, the link is back to the training module index.