### PR TITLE
Drop Govspeak which is not yet secure for use with Rails 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ WORKDIR ${APP_HOME}
 COPY Gemfile $APP_HOME/Gemfile
 COPY Gemfile.lock $APP_HOME/Gemfile.lock
 
-RUN bundle config set frozen true
 RUN bundle config set no-cache true
 RUN bundle config set without development test
 RUN bundle install --no-binstubs --retry=10 --jobs=4

--- a/Gemfile
+++ b/Gemfile
@@ -47,8 +47,7 @@ gem 'active_hash'
 gem "govuk-components", ">= 3.0.3"
 gem "govuk_design_system_formbuilder"
 
-gem "govspeak"              # Convert govspeak markdown to HTML
-gem 'rexml'                 # Required for govspeak to work
+gem "kramdown", "~> 2.3"      # Markdown support
 
 group :development, :test do
   # Use fake data for specs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,6 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.3.8)
     bcrypt (3.1.17)
     bindex (0.8.1)
     bootsnap (1.11.1)
@@ -106,12 +105,6 @@ GEM
     foreman (0.87.2)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    govspeak (3.6.2)
-      addressable (~> 2.3.8)
-      htmlentities (~> 4)
-      kramdown (~> 1.10.0)
-      nokogiri (~> 1.5)
-      sanitize (~> 2.1.0)
     govuk-components (3.0.3)
       activemodel (>= 6.1)
       railties (>= 6.1)
@@ -138,7 +131,6 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
-    htmlentities (4.3.4)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.0.3)
@@ -154,7 +146,8 @@ GEM
     jsbundling-rails (1.0.2)
       railties (>= 6.0.0)
     jwt (2.3.0)
-    kramdown (1.10.0)
+    kramdown (2.3.1)
+      rexml
     loofah (2.15.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -251,8 +244,6 @@ GEM
     rspec-support (3.11.0)
     ruby_parser (3.18.1)
       sexp_processor (~> 4.16)
-    sanitize (2.1.1)
-      nokogiri (>= 1.4.4)
     sexp_processor (4.16.0)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
@@ -305,7 +296,6 @@ DEPENDENCIES
   factory_bot_rails
   faker
   foreman
-  govspeak
   govuk-components (>= 3.0.3)
   govuk_design_system_formbuilder
   govuk_notify_rails (~> 2.2, >= 2.2.0)
@@ -313,10 +303,10 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   jsbundling-rails
+  kramdown (~> 2.3)
   pg (~> 1.1)
   puma (~> 5.6)
   rails (>= 7.0.2.3)
-  rexml
   rspec-rails
   sprockets-rails
   stimulus-rails

--- a/adr/0005-content-storage-strategy.md
+++ b/adr/0005-content-storage-strategy.md
@@ -1,4 +1,4 @@
-# Use YAML + GovSpeak for Content
+# Use YAML + Markdown for Content
 
 * Status: accepted
 
@@ -17,15 +17,15 @@ How might we introduce/store both module content and assessment content in the a
 
 * Integrate with a commercial CMS, e.g. Contentful
 * Adapt the EYFS Reforms CMS
-* Create content as a mix of YAML and GovSpeak and mechanically translate to GDS compliant HTML
+* Create content as a mix of YAML and Markdown and mechanically translate to GDS compliant HTML
 * Create GDS compliant HTML by hand
 
 ## Decision Outcome
 
-Chosen option: Create content as a mix of YAML and GovSpeak and mechanically translate to GDS compliant HTML.
+Chosen option: Create content as a mix of YAML and Markdown and mechanically translate to GDS compliant HTML.
 * A CMS would not natively support the creation of either questionnaire or navigation content, therefore this data would need to be stored and processed elsewhere. 
 * Any content stored in a CMS would also need to be translated into GDS compliant HTML. 
 * The integration of a CMS would be a non-complex task, as would modifying the EYFS Reforms CMS to support these additional requirements in the timescales we currently have.
 * Creating GDS compliant HTML directly would require intensive developer support.
 
-Using a text based YAML+GovSpeak file and building a translation and navigation engine would give the Content Editors a simple structure by which then could create content but, once the engine is developed, minimal developer support would be needed to add extra content.
+Using a text based YAML+Markdown file and building a translation and navigation engine would give the Content Editors a simple structure by which then could create content but, once the engine is developed, minimal developer support would be needed to add extra content.

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -1,6 +1,6 @@
 module ContentHelper
   def translate_markdown(markdown)
-    doc = Govspeak::Document.new markdown
+    doc = Kramdown::Document.new markdown
     raw doc.to_html
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -15,7 +15,7 @@
 
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_include_tag "application", "data-turbo-track": "reload", defer: true
-  %body.govuk-template__body
+  %body.govuk-template__body.govuk-body
     %script
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     


### PR DESCRIPTION
Snyk has identified a vulnerability in Govspeak version 3, however the patched version 6 is not yet compatible with Rails 7.