### PR TITLE
Add Model for Youtube pages with matching template

### DIFF
--- a/app/models/concerns/translate_from_locale.rb
+++ b/app/models/concerns/translate_from_locale.rb
@@ -1,0 +1,12 @@
+module TranslateFromLocale
+  def translate(label)
+    # Suppress translation returning "translation missing" message so validation for presence works
+    return unless I18n.exists?([i18n_scope, label])
+
+    I18n.t(label, scope: i18n_scope)
+  end
+
+  def i18n_scope
+    [:modules, training_module, name]
+  end
+end

--- a/app/models/content_page.rb
+++ b/app/models/content_page.rb
@@ -1,14 +1,11 @@
 class ContentPage
   include ActiveModel::Validations
   include ActiveModel::Model
+  include TranslateFromLocale
 
   attr_accessor :id, :name, :type, :training_module
 
   validates :heading, :body, presence: true
-
-  def i18n_scope
-    [:modules, training_module, name]
-  end
 
   def heading
     translate(:heading)
@@ -20,12 +17,5 @@ class ContentPage
 
   def image
     translate(:image)
-  end
-
-  def translate(label)
-    # Suppress translation returning "translation missing" message so validation for presence works
-    return unless I18n.exists?([i18n_scope, label])
-    
-    I18n.t(label, scope: i18n_scope)
   end
 end

--- a/app/models/module_item.rb
+++ b/app/models/module_item.rb
@@ -3,6 +3,7 @@ class ModuleItem < YamlBase
     module_intro: ContentPage,
     sub_module_intro: ContentPage,
     text_page: ContentPage,
+    youtube_page: YoutubePage,
     formative_assessment: Questionnaire
   }
 

--- a/app/models/youtube_page.rb
+++ b/app/models/youtube_page.rb
@@ -1,0 +1,32 @@
+class YoutubePage
+  include ActiveModel::Validations
+  include ActiveModel::Model
+  include TranslateFromLocale
+
+  attr_accessor :id, :name, :type, :training_module
+
+  validates :heading, :body, :youtube_url, presence: true
+
+  # To display without error the Youtube URL should be the embedded url.
+  # On the target video page, click Share and then selected embeded.
+  # Use the URL within the embeded code. For example:
+  #  https://www.youtube.com/embed/ucjmWjJ25Ho
+  #
+  validates :youtube_url, format: /\Ahttps:\/\/www\.youtube\.com\/embed/
+
+  def heading
+    translate(:heading)
+  end
+
+  def body
+    translate(:body)
+  end
+
+  def video_title
+    translate(:video_title)
+  end
+
+  def youtube_url
+    translate(:youtube_url)
+  end
+end

--- a/app/views/content_pages/youtube_page.html.slim
+++ b/app/views/content_pages/youtube_page.html.slim
@@ -1,0 +1,8 @@
+h1=@model.heading
+.govspeak-embed-container
+  iframe.govspeak-embed-video width="560" height="315" src=@model.youtube_url title=@model.video_title frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+p=translate_markdown(@model.body)
+p
+  =link_to_previous_module_item(@module_item)
+  =link_to_next_module_item(@module_item)
+

--- a/config/locales/modules/one.yml
+++ b/config/locales/modules/one.yml
@@ -1,12 +1,6 @@
 ---
 en:
   modules:
-    test:
-      test:
-        heading: A test
-      basic:
-        heading: A text page
-        body: Some text
     one:
       1:
         heading: Module 1 - Foo
@@ -33,5 +27,3 @@ en:
       1-2-3:
         heading: How to avoid the stuff haters
         body: Hide behind stuff
-
-

--- a/config/locales/modules/supporting-physical-development-in-the-early-years.yml
+++ b/config/locales/modules/supporting-physical-development-in-the-early-years.yml
@@ -23,3 +23,15 @@ en:
           ## Course feedback
 
           Next, you can tell us what you thought about this course.
+      2:
+        heading: What is GOV.UK
+        video_title: What is GOV.UK
+        youtube_url: https://www.youtube.com/embed/ucjmWjJ25Ho
+        body: |
+          Government Digital Service
+
+          GOV.UK is the single website for all central government services and information. It launched in 2012 and replaced nearly 2,000 government websites.
+
+          GOV.UK has been viewed more than 14 billion times since it went live. It gets an average 3.6 million visits a day. It has won awards and it has influenced governments all over the world from Australia to Israel.
+
+          But GOV.UK is much more than just a website for government - it’s the digital interface for millions of people interacting with central government.

--- a/config/locales/modules/test.yml
+++ b/config/locales/modules/test.yml
@@ -1,0 +1,14 @@
+---
+en:
+  modules:
+    test:
+      test:
+        heading: A test
+      basic:
+        heading: A text page
+        body: Some text
+      video:
+        heading: A video
+        video_title: What is GOV.UK
+        youtube_url: https://www.youtube.com/embed/ucjmWjJ25Ho
+        body: Some text

--- a/data/modules/supporting-physical-development-in-the-early-years.yml
+++ b/data/modules/supporting-physical-development-in-the-early-years.yml
@@ -2,3 +2,5 @@
 supporting-physical-development-in-the-early-years:
   1:
     type: module_intro
+  2:
+    type: youtube_page

--- a/data/modules/test.yml
+++ b/data/modules/test.yml
@@ -4,3 +4,5 @@ test:
     type: formative_assessment
   basic:
     type: text_page
+  video:
+    type: youtube_page

--- a/spec/models/content_page_spec.rb
+++ b/spec/models/content_page_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ContentPage, type: :model do
-  let(:content) { YAML.load_file(Rails.root.join("config/locales/modules.yml")).dig("en", "modules", "test") }
+  let(:content) { YAML.load_file(Rails.root.join("config/locales/modules/test.yml")).dig("en", "modules", "test") }
   let(:content_page) { ContentPage.new(id: :basic, training_module: :test, type: :text_page) }
 
   describe "#heading" do

--- a/spec/models/module_item_spec.rb
+++ b/spec/models/module_item_spec.rb
@@ -63,5 +63,17 @@ RSpec.describe ModuleItem, type: :model do
         expect(model.name).to eq(module_item.name)
       end
     end
+
+    context "when model is a youtube page" do
+      let(:module_item) { described_class.find_by(training_module: :test, type: :youtube_page) }
+
+      it "returns a Youtube page" do
+        expect(model).to be_a(YoutubePage)
+      end
+
+      it "matches the module item" do
+        expect(model.name).to eq(module_item.name)
+      end
+    end
   end
 end

--- a/spec/models/youtube_page_spec.rb
+++ b/spec/models/youtube_page_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe YoutubePage, type: :model do
+  let(:content) { YAML.load_file(Rails.root.join("config/locales/modules/test.yml")).dig("en", "modules", "test") }
+  let(:youtube_page) { described_class.new(name: :video, training_module: :test, type: :youtube_page) }
+
+  describe "#heading" do
+    it "returns the heading data from the content file" do
+      expect(youtube_page.heading).to eq(content.dig(youtube_page.name.to_s, 'heading'))
+    end
+  end
+
+  describe "#body" do
+    it "returns the body data from the content file" do
+      expect(youtube_page.body).to eq(content.dig(youtube_page.name.to_s, 'body'))
+    end
+  end
+
+  describe "#video_title" do
+    it "returns the video title data from the content file" do
+      expect(youtube_page.video_title).to eq(content.dig(youtube_page.name.to_s, 'video_title'))
+    end
+  end
+
+  describe "#youtube_url" do
+    it "returns the Youtube URL data from the content file" do
+      expect(youtube_page.youtube_url).to eq(content.dig(youtube_page.name.to_s, 'youtube_url'))
+    end
+
+    it "is valid" do
+      expect(youtube_page).to be_valid
+    end
+
+    context "when URL is not for an embeded youtube video" do
+      before { allow(youtube_page).to receive(:youtube_url).and_return("http://example.com") }
+
+      it "is invalid" do
+        expect(youtube_page).to be_invalid
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows a page type to be specified that includes a Youtube video.
Also separates the "test" and "one" content data into separate files.

With this in place the page at `modules/supporting-physical-development-in-the-early-years/content_pages/2` render as shown below:
![youtube_page](https://user-images.githubusercontent.com/213040/159287860-c8281409-c318-4c86-b5b5-f39cf8ab5d7a.png)

