### PR TITLE
ER 121 - Add a static controller with a sample page

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,0 +1,5 @@
+class StaticController < ApplicationController
+  def show
+    render params[:id]
+  end
+end

--- a/app/views/static/terms_and_conditions.html.slim
+++ b/app/views/static/terms_and_conditions.html.slim
@@ -1,0 +1,3 @@
+h1 = t(".heading")
+
+.content = translate_markdown(t(".content"))

--- a/config/locales/static/terms_and_conditions.yml
+++ b/config/locales/static/terms_and_conditions.yml
@@ -1,0 +1,6 @@
+---
+en:
+  static:
+    terms_and_conditions:
+      heading: Terms and conditions
+      content: \[content goes here\]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,6 @@ Rails.application.routes.draw do
     resources :content_pages, only: [:index, :show]
     resources :questionnaires, only: [:show, :update]
   end
+
+  resources :static, only: :show
 end

--- a/spec/requests/static_spec.rb
+++ b/spec/requests/static_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Static", type: :request do
+  describe "GET static/terms_and_conditions" do
+    it "renders successfully" do
+      get static_path(:terms_and_conditions)
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
Adds a static terms and conditions page

The page renders at `/static/terms_and_conditions` as shown below

![terms_and_conditions](https://user-images.githubusercontent.com/213040/160575806-13b341bb-396a-4eb7-a67a-d3c09f5752bb.png)

