### PR TITLE
ER-141 Inactivity logged out page

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,3 +1,4 @@
 class ErrorsController < ApplicationController
   def not_found; end
+  def timeout; end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,7 @@
 class ErrorsController < ApplicationController
   def not_found; end
-  def timeout; end
+
+  def timeout
+    @user_timeout_minutes = Rails.configuration.x.user_timeout_minutes
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :timeoutable, :trackable, :recoverable and :omniauthable
   devise :database_authenticatable, :registerable, :recoverable,
-         :validatable, :rememberable, :confirmable, :lockable
+         :validatable, :rememberable, :confirmable, :lockable, :timeoutable
 
   def name
     [first_name, last_name].compact.join(' ')

--- a/app/views/errors/timeout.html.slim
+++ b/app/views/errors/timeout.html.slim
@@ -1,0 +1,3 @@
+h1 For your security, we signed you out
+p="You have not done anything for #{Rails.configuration.x.user_timeout_minutes} minutes"
+p=link_to 'Sign in', new_user_session_path, class: 'govuk-button'

--- a/app/views/errors/timeout.html.slim
+++ b/app/views/errors/timeout.html.slim
@@ -1,3 +1,3 @@
 h1 For your security, we signed you out
-p="You have not done anything for #{Rails.configuration.x.user_timeout_minutes} minutes"
+p="You have not done anything for #{@user_timeout_minutes} minutes"
 p=link_to 'Sign in', new_user_session_path, class: 'govuk-button'

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,8 @@ module EarlyYearsFoundationRecovery
     end
 
     config.feedback_url = ENV.fetch('FEEDBACK_URL', '#FEEDBACK_URL_env_var_missing')
+
+    # Timeout - number of minutes of inactivity before a user is logged out
+    config.x.user_timeout_minutes = 30
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,18 @@
 # Turbo doesn't work with devise by default.
 # Keep tabs on https://github.com/heartcombo/devise/issues/5446 for a possible fix
 # Fix from https://gorails.com/episodes/devise-hotwire-turbo
-class TurboFailureApp < Devise::FailureApp
+
+class CustomFailureApp < Devise::FailureApp
+  def redirect
+    store_location!
+    message = warden.message || warden_options[:message]
+    if message == :timeout
+      redirect_to users_timeout_path
+    else
+      super
+    end
+  end
+
   def respond
     if request_format == :turbo_stream
       redirect
@@ -206,7 +217,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = Rails.configuration.x.user_timeout_minutes.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.
@@ -296,7 +307,7 @@ Devise.setup do |config|
   # change the failure app, you can configure them inside the config.warden block.
   #
   config.warden do |manager|
-    manager.failure_app = TurboFailureApp
+    manager.failure_app = CustomFailureApp
     #   manager.intercept_401 = false
     #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root 'home#index'
 
   get '/404', to: 'errors#not_found', via: :all
+  get 'users/timeout', to: 'errors#timeout'
   get 'health', to: 'home#show'
 
   devise_for :users, controllers: { sessions: 'users/sessions' }

--- a/spec/controllers/training_modules_controller_spec.rb
+++ b/spec/controllers/training_modules_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe TrainingModulesController, type: :controller do
+  # Using a controller spec as need to access session to test timeout
+  describe 'user timeout' do
+    before do
+      sign_in create(:user, :registered)
+    end
+
+    it 'allows user to access target page' do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+
+    context 'when user has times out' do
+      let(:timeout) { Rails.configuration.x.user_timeout_minutes.minutes + 1.second }
+
+      it 'redirects to timeout error' do
+        get :index, session: { 'warden.user.user.session' => { 'last_request_at' => timeout.ago } }
+        expect(response).to redirect_to(users_timeout_path)
+      end
+    end
+  end
+end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -7,4 +7,11 @@ RSpec.describe 'Errors', type: :request do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'timeout' do
+    it 'returns http success' do
+      get users_timeout_path
+      expect(response).to have_http_status(:success)
+    end
+  end
 end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,4 +1,4 @@
 RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
-  config.include Devise::Test::IntegrationHelpers
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end


### PR DESCRIPTION
Redirect user to timeout page after 30 minutes of inactivity

[Jira Ticket](https://dfedigital.atlassian.net/browse/ER-141)

With this change in place, if a user tries to access a page after the timeout, they are redirected to this page (please note that I reduced the timeout to 1 minute to test - hence the short time shown on the message):

![users_timeout](https://user-images.githubusercontent.com/213040/161759905-198fd353-e75a-4822-a0db-4e3e3b36863b.png)

Note that as warden stores the last request time in session, to test the behaviour session needs to be manipulated. The easiest way to do that is within a controller spec. Therefore, a controller spec was used to test the behaviour rather than a request spec.