### PR TITLE
ER-157 Store users answers for each questionnaire

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable, :recoverable,
          :validatable, :rememberable, :confirmable, :lockable, :timeoutable
 
+  has_many :user_answers
+
   def name
     [first_name, last_name].compact.join(' ')
   end

--- a/app/models/user_answer.rb
+++ b/app/models/user_answer.rb
@@ -1,0 +1,11 @@
+class UserAnswer < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+
+  belongs_to :user
+  belongs_to :questionnaire
+
+  serialize :answer, Array
+
+  # Need to use IS as `where.not(archive: true)` always returns nil
+  scope :not_archived, -> { where 'user_answers.archived IS NOT true' }
+end

--- a/db/migrate/20220414093951_create_user_answers.rb
+++ b/db/migrate/20220414093951_create_user_answers.rb
@@ -1,0 +1,14 @@
+class CreateUserAnswers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_answers do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :questionnaire_id, null: false, index: true
+      t.string :question
+      t.string :answer
+      t.boolean :correct
+      t.boolean :archived
+      t.index %i[questionnaire_id user_id]
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_31_135702) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_14_093951) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "user_answers", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "questionnaire_id", null: false
+    t.string "question"
+    t.string "answer"
+    t.boolean "correct"
+    t.boolean "archived"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["questionnaire_id", "user_id"], name: "index_user_answers_on_questionnaire_id_and_user_id"
+    t.index ["questionnaire_id"], name: "index_user_answers_on_questionnaire_id"
+    t.index ["user_id"], name: "index_user_answers_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -40,4 +54,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_31_135702) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token"
   end
 
+  add_foreign_key "user_answers", "users"
 end

--- a/spec/factories/user_answers.rb
+++ b/spec/factories/user_answers.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user_answer do
+    user
+    questionnaire { Questionnaire.find_by(name: :test, training_module: :test) }
+    question { Faker::Lorem.word }
+    answer { [Faker::Lorem.word] }
+  end
+end

--- a/spec/models/user_answer_spec.rb
+++ b/spec/models/user_answer_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe UserAnswer, type: :model do
+  let(:user_answer) { create :user_answer }
+
+  # Testing this association to check ActiveHash associations are working
+  it 'is associated with a questionnaire' do
+    expect(user_answer.questionnaire).to be_a(Questionnaire)
+  end
+end

--- a/spec/requests/questionnaires_spec.rb
+++ b/spec/requests/questionnaires_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'Questionnaires', type: :request do
   let(:questionnaire) { Questionnaire.find_by(name: :test, training_module: :test) }
+  let(:user) { create(:user, :registered) }
 
   before do
-    sign_in create(:user, :registered)
+    sign_in user
   end
 
   describe 'GET /questionnaires/:id' do
@@ -26,28 +27,62 @@ RSpec.describe 'Questionnaires', type: :request do
   end
 
   describe 'PATCH /questionaires/:id' do
-    let(:correct_answers) do
+    subject(:submit_questionnaire) do
+      patch training_module_questionnaire_path(:test, questionnaire), params: { questionnaire: answers }
+    end
+
+    let(:answers) do
       questionnaire.questions.transform_values do |question|
         question[:multi_select] ? question[:correct_answers] : question[:correct_answers].first
       end
     end
 
-    let(:incorrect_answers) do
-      questionnaire.questions.transform_values { |_a| :foo }
-    end
-
     let(:module_item) { ModuleItem.find_by(training_module: questionnaire.training_module, name: questionnaire.name) }
 
     it 'does something without error' do
-      patch training_module_questionnaire_path(:test, questionnaire), params: { questionnaire: correct_answers }
+      submit_questionnaire
       expect(response).to redirect_to(training_module_content_page_path(module_item.training_module, module_item.next_item))
     end
 
+    it 'creates a record of the answer' do
+      expect { submit_questionnaire }.to change(UserAnswer, :count).by(questionnaire.questions.size)
+    end
+
+    it 'flags the stored answer as correct' do
+      submit_questionnaire
+      expect(UserAnswer.last).to be_correct
+    end
+
     context 'with incorrect answers' do
+      let(:answers) { questionnaire.questions.transform_values { |_a| :foo } }
+
       it 'renders page with errors' do
-        patch training_module_questionnaire_path(:test, questionnaire), params: { questionnaire: incorrect_answers }
+        submit_questionnaire
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.body).to include('class="errors"')
+      end
+
+      it 'creates a record of the answer' do
+        expect { submit_questionnaire }.to change(UserAnswer, :count).by(questionnaire.questions.size)
+      end
+
+      it 'flags the stored answer as not correct' do
+        submit_questionnaire
+        expect(UserAnswer.last).not_to be_correct
+      end
+    end
+
+    context 'with an existing user answer' do
+      let!(:user_answer) { create :user_answer, user: user, questionnaire: questionnaire }
+
+      it 'archives the existing user answer' do
+        submit_questionnaire
+        expect(user_answer.reload).to be_archived
+      end
+
+      it 'does not archive the new user answers' do
+        submit_questionnaire
+        expect(UserAnswer.last).not_to be_archived
       end
     end
   end


### PR DESCRIPTION
[Jira ER-157](https://dfedigital.atlassian.net/browse/ER-157)

## Summary

Add a model to record user answers and update questionnaire controller to populate it.

Each question in a questionnaire will have an active (not archived) `UserAnswer` for the user who submits it. Previous user answers are archived (rather than updated or deleted) as there is a requirement to assess the number of attempts a user makes to get the correct answer.

## Acceptance Criteria

- [x] **be associated with the current user**
- [x] **be associated with the current questionnaire**
- [x] **store the submitted answers - note that the questions may be spread across a number of pages: so it must be possible for answers to be built up incrementally.** Note that this will work, as each question has its own record, but the way of archiving previous user answers will need to be updated as current all existing associated user answers are archived on update. It will need to be changed to either archive a question at a time, or archive all on returning to first question for multi-page questionnaires.
- [x] **populate the questionnaire form with the submitted answers when the user returns the questionnaire page**
- [x] **the answers should be stored in a way that allows them to be compared with correct answers at a later point.** As the comparison was already happening in the controller, it seemed easier to do the correct answer comparison here rather than at a later point.

The assessment is made as to whether an answer is correct as each is stored. This allows the number of correct answers to be determined via:
```ruby
UserAnswer.not_archived.where(user: user, questionnaire: questionnaire, correct: true).count
```
And this can be compared with `UserAnswer.not_archived.where(user: user, questionnaire: questionnaire).count` to determine the percentage correct.

