### PR TITLE
ER-160 Restyle buttons in questionnaire forms to "Previous" and “Next” buttons

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,13 +39,13 @@ module ApplicationHelper
     end
   end
 
-  def link_to_previous_module_item(module_item)
+  def link_to_previous_module_item(module_item, link_args = {})
     link =
       if module_item.previous_item
         training_module_content_page_path(module_item.training_module, module_item.previous_item)
       else
         training_modules_path
       end
-    link_to 'Previous', link
+    link_to 'Previous', link, link_args
   end
 end

--- a/app/views/questionnaires/show.html.slim
+++ b/app/views/questionnaires/show.html.slim
@@ -19,5 +19,9 @@ p=@questionnaire.content
             = input.radio_button
           = input.label
 
-  = submit_tag "Submit"
-  p= link_to_previous_module_item(@questionnaire.module_item)
+  hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-4"
+  .govuk-grid-row
+    .govuk-grid-column-one-half
+      = link_to_previous_module_item(@questionnaire.module_item, class: "govuk-button govuk-button--secondary")
+    div class="govuk-grid-column-one-half govuk-!-text-align-right"
+      = submit_tag "Next", class: "govuk-button"


### PR DESCRIPTION
[Jira ER-160](https://dfedigital.atlassian.net/browse/ER-160)

## Acceptance criteria

Restyle these two so that:

- A solid boarder appears above the two buttons
- The two buttons are positioned at the same height on the page with the previous link to the left, and next/submit button on the right
- The previous link is restyled as a [GOV.UK](http://gov.uk/) Secondary button
- The next/submit button is restyles as a [GOV.UK](http://gov.uk/) button and the text changed to “Next”

## After changes
In a desktop browser
![questionnaire_buttons](https://user-images.githubusercontent.com/213040/163991003-0775ae3a-27b9-4864-986b-94ae7f043723.png)

In a narrow browser window

![questionnaire_buttons_narrow](https://user-images.githubusercontent.com/213040/163991041-7f13f440-a333-48ff-9396-dc3dffccf953.png)

