### PR TITLE
Adds methods to determine the position of a module item

### DIFF
--- a/app/models/module_item.rb
+++ b/app/models/module_item.rb
@@ -25,13 +25,13 @@ class ModuleItem < YamlBase
 
   # Returns all the module items that belong to a particular topic within a training module
   scope :where_topic, lambda { |training_module, topic|
-    pattern = /\A\d+\W#{topic}(?=(\D|$))/ # Start with number, then non-word (e.g. - or .). Can be followed by either a non-digit or end of line
+    pattern = /\A(\d+\W){2}#{topic}(?=(\D|$))/ # Start with two number then non-word character pairs (e.g. 2-4- or 13.4.). Can be followed by either a non-digit or end of line
     where(training_module: training_module).select { |m| m.name =~ pattern }
   }
 
   # rubocop:disable Lint/MixedRegexpCaptureTypes
   def topic
-    pattern = /\A\d+\W(?<topic>\d+)(?=(\D|$))/
+    pattern = /\A(\d+\W){2}(?<topic>\d+)(?=(\D|$))/
     matches = name.match(pattern)
     matches[:topic] if matches
   end

--- a/spec/factories/module_items.rb
+++ b/spec/factories/module_items.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  # Note that items created via this factory persist across tests so will need to be cleaned up after each use.
+  # This can be done via:
+  #   after do
+  #    described_class.delete_all
+  #    described_class.reload(true)
+  #  end
+  # See: https://github.com/active-hash/active_hash#saving-in-memory-records
+  factory :module_item do
+    training_module { :test }
+  end
+end

--- a/spec/models/module_item_spec.rb
+++ b/spec/models/module_item_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe ModuleItem, type: :model do
 
   describe '.where_topic' do
     let!(:topic_one_item) { create :module_item, name: '1-1-1' }
-    let!(:topic_two_item) { create :module_item, name: '1-2-1' }
+    let!(:topic_two_item) { create :module_item, name: '1-1-2' }
 
     it 'returns module items matching the topic' do
       expect(described_class.where_topic(:test, 1)).to include(topic_one_item)
@@ -99,14 +99,14 @@ RSpec.describe ModuleItem, type: :model do
 
   describe '#topic' do
     let(:topic) { Faker::Number.number(digits: 2).to_s }
-    let(:module_item) { create :module_item, name: "22-#{topic}-1" }
+    let(:module_item) { create :module_item, name: "22-1-#{topic}" }
 
     it 'extracts the topic number from the name' do
       expect(module_item.topic).to eq(topic)
     end
 
-    context 'with topic intro' do
-      let(:module_item) { create :module_item, name: "33-#{topic}" }
+    context 'with topic subpage' do
+      let(:module_item) { create :module_item, name: "33-22-#{topic}-3" }
 
       it 'extracts the topic number from the name' do
         expect(module_item.topic).to eq(topic)
@@ -115,9 +115,9 @@ RSpec.describe ModuleItem, type: :model do
   end
 
   describe '#position_within_topic' do
-    let!(:topic_item_one) { create :module_item, name: '1-1-1' }
-    let!(:topic_item_two) { create :module_item, name: '1-1-2' }
-    let!(:topic_item_three) { create :module_item, name: '1-1-5' }
+    let!(:topic_item_one) { create :module_item, name: '1-1-2' }
+    let!(:topic_item_two) { create :module_item, name: '1-1-2-1' }
+    let!(:topic_item_three) { create :module_item, name: '1-1-2-5' }
 
     it 'returns the position of the item within the topic' do
       expect(topic_item_one.position_within_topic).to eq(0)

--- a/spec/models/module_item_spec.rb
+++ b/spec/models/module_item_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe ModuleItem, type: :model do
   let(:yaml_data) { data_from_file('modules/test.yml') }
   let(:module_item) { described_class.where(training_module: :test).first }
 
+  after do
+    described_class.delete_all
+    described_class.reload(true)
+  end
+
   it 'loads data from file' do
     expect(module_item.type).to eq(yaml_data.dig('test', module_item.name, 'type'))
   end
@@ -74,6 +79,63 @@ RSpec.describe ModuleItem, type: :model do
       it 'matches the module item' do
         expect(model.name).to eq(module_item.name)
       end
+    end
+  end
+
+  describe '.where_topic' do
+    let!(:topic_one_item) { create :module_item, name: '1-1-1' }
+    let!(:topic_two_item) { create :module_item, name: '1-2-1' }
+
+    it 'returns module items matching the topic' do
+      expect(described_class.where_topic(:test, 1)).to include(topic_one_item)
+      expect(described_class.where_topic(:test, 2)).to include(topic_two_item)
+    end
+
+    it 'does not return items from other topics' do
+      expect(described_class.where_topic(:test, 1)).not_to include(topic_two_item)
+      expect(described_class.where_topic(:test, 2)).not_to include(topic_one_item)
+    end
+  end
+
+  describe '#topic' do
+    let(:topic) { Faker::Number.number(digits: 2).to_s }
+    let(:module_item) { create :module_item, name: "22-#{topic}-1" }
+
+    it 'extracts the topic number from the name' do
+      expect(module_item.topic).to eq(topic)
+    end
+
+    context 'with topic intro' do
+      let(:module_item) { create :module_item, name: "33-#{topic}" }
+
+      it 'extracts the topic number from the name' do
+        expect(module_item.topic).to eq(topic)
+      end
+    end
+  end
+
+  describe '#position_within_topic' do
+    let!(:topic_item_one) { create :module_item, name: '1-1-1' }
+    let!(:topic_item_two) { create :module_item, name: '1-1-2' }
+    let!(:topic_item_three) { create :module_item, name: '1-1-5' }
+
+    it 'returns the position of the item within the topic' do
+      expect(topic_item_one.position_within_topic).to eq(0)
+      expect(topic_item_two.position_within_topic).to eq(1)
+    end
+
+    it 'uses position in array rather than last digit in name' do
+      expect(topic_item_three.position_within_topic).to eq(2)
+    end
+  end
+
+  describe '#position_within_training_module' do
+    let(:first_item) { described_class.find_by(training_module: :test) }
+    let(:last_item) { described_class.where(training_module: :test).last }
+
+    it 'return position in array of module items in training module' do
+      expect(first_item.position_within_training_module).to eq(0)
+      expect(last_item.position_within_training_module).to eq(described_class.where(training_module: :test).count - 1)
     end
   end
 end


### PR DESCRIPTION
Some methods have been added to `ModuleItem` to make it easier to determent where in a training module and/or topic a particular page is. As each page in a training module has a unique module item, these methods will make it easier to track and report on progress through a training module.

This PR also adds a factory for module items

The methods added are:

- `.where_topic` which takes a training module name and topic number and returns all the matching module items in the order they are defined within the YAML files
- `#topic` returns the topic number if the module item name is of the form `1-2-1`, `1.2.1` or `1-2-2-4`, where that number is the third digit group in the sequence (or last digit if just three numbers e.g. 2 from `1-1-2`)
- `#position_within_topic` returns the module item's index position (so first one is zero) within its own topic
- `#position_within_training_module` returns the module item's index position within its training module