### PR TITLE
ER-156: Add required percentage correct threshold to questionnaire data

### DIFF
--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -41,7 +41,7 @@ private
       # Put into an array and then flattened so single and multi-choice questions can be handled in the same way
       answer = [questionnaire_params[question]].flatten.select(&:present?)
       current_user.user_answers.create!(
-        questionnaire: questionnaire,
+        questionnaire_id: questionnaire.id,
         question: question,
         answer: answer,
         correct: answer == data[:correct_answers],

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -11,10 +11,10 @@ class QuestionnairesController < ApplicationController
   def update
     questionnaire.errors.clear
     update_questionnaire
-    if user_answers.all?(&:correct)
+
+    if questionnaire.valid?
       redirect_to training_module_content_page_path(training_module, next_module_item)
     else
-      generate_error_messages
       render :show, status: :unprocessable_entity
     end
   end
@@ -46,12 +46,6 @@ private
         answer: answer,
         correct: answer == data[:correct_answers],
       )
-    end
-  end
-
-  def generate_error_messages
-    user_answers.map do |user_answer|
-      questionnaire.errors.add user_answer.question, "is#{' not' unless user_answer.correct?} correct"
     end
   end
 

--- a/app/models/module_item.rb
+++ b/app/models/module_item.rb
@@ -48,7 +48,7 @@ class ModuleItem < YamlBase
   def model
     klass = MODELS[type.to_sym]
     if klass == Questionnaire
-      Questionnaire.find_by(name: name)
+      Questionnaire.find_by!(name: name)
     else
       klass.new(attributes)
     end

--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -31,7 +31,7 @@ private
   def results
     @results ||= questions.each_with_object({}) do |(question, data), hash|
       hash[question] = if data[:correct_answers].present?
-                         send(question) == data[:correct_answers]
+                         flattened_array(send(question)) == flattened_array(data[:correct_answers])
                        else
                          true # If there are no correct answers set, assume any answer much be true
                        end
@@ -44,5 +44,9 @@ private
 
   def percentage_of_answers_correct
     (number_of_correct_answers / questions.length.to_f) * 100
+  end
+
+  def flattened_array(item)
+    [item].flatten.select(&:present?)
   end
 end

--- a/app/models/questionnaire_data.rb
+++ b/app/models/questionnaire_data.rb
@@ -1,0 +1,34 @@
+# ActiveYaml objects are effectively singletons. That is, each one is loaded into memory at application start and
+# processes like `find_by` grab the matching instance and return that rather than spawning a new matching instance.
+# That adds complications when using instances to populate forms and hold per transaction data. Data from
+# one transaction can pollute another as both share the same singleton instance. Therefore, the questionnaires model is
+# split into two:
+#   - QuestionnaireData - that holds the unchanging questionnaire structure as defined via YAML files
+#   - Questionnaire - that handles the transactions that occur when a user interacts with a questionnaire
+
+class QuestionnaireData < YamlBase
+  extend YamlFolder
+
+  set_folder 'questionnaires'
+
+  def self.load_file
+    data = raw_data.map do |training_module, questionnaires|
+      questionnaires.map do |name, field|
+        field['name'] = name
+        field['training_module'] = training_module
+        field['questions'].deep_symbolize_keys!
+        field
+      end
+    end
+    data.flatten! # Using flatten! as more memory efficient.
+    data
+  end
+
+  def build_questionnaire
+    # Need to deeply duplicate attributes as otherwise changes to questionnaire questions will be replicated
+    # across all instances of a given questionnaire.
+    attrs = attributes.deep_dup
+    attrs[:questionnaire_data] = self
+    Questionnaire.new(attrs)
+  end
+end

--- a/app/models/user_answer.rb
+++ b/app/models/user_answer.rb
@@ -2,7 +2,11 @@ class UserAnswer < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
 
   belongs_to :user
-  belongs_to :questionnaire
+  belongs_to :questionnaire_data, foreign_key: :questionnaire_id
+
+  def questionnaire
+    @questionnaire ||= questionnaire_data.build_questionnaire
+  end
 
   serialize :answer, Array
 

--- a/app/views/questionnaires/show.html.slim
+++ b/app/views/questionnaires/show.html.slim
@@ -1,7 +1,7 @@
 h1=@questionnaire.heading
 p=@questionnaire.content
 
-= form_with model: @questionnaire, url: training_module_questionnaire_path(@training_module, @questionnaire) do |form|
+= form_with model: @questionnaire, url: training_module_questionnaire_path(@training_module, @questionnaire), method: :patch do |form|
   - if @questionnaire.errors.present?
     .errors=@questionnaire.errors.messages
   - @questionnaire.questions.each do |question, data|

--- a/data/questionnaires/one.yml
+++ b/data/questionnaires/one.yml
@@ -3,6 +3,7 @@ one:
   1-1-4:
     heading: A Question of Stuff
     content: A simple question
+    required_percentage_correct: 100
     questions:
       like_stuff:
         multi_select: false

--- a/spec/factories/user_answers.rb
+++ b/spec/factories/user_answers.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user_answer do
     user
-    questionnaire { Questionnaire.find_by(name: :test, training_module: :test) }
+    questionnaire_data { QuestionnaireData.find_by!(name: :test, training_module: :test) }
     question { Faker::Lorem.word }
     answer { [Faker::Lorem.word] }
   end

--- a/spec/models/questionnaire_data_spec.rb
+++ b/spec/models/questionnaire_data_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe QuestionnaireData, type: :model do
+  let(:yaml_data) { data_from_file('questionnaires/test.yml') }
+  let(:questionnaire_data) { described_class.find_by!(name: :test, training_module: :test) }
+
+  it 'loads basic method' do
+    expect(questionnaire_data.heading).to eq(yaml_data.dig('test', 'test', 'heading'))
+    expect(questionnaire_data.content).to eq(yaml_data.dig('test', 'test', 'content'))
+  end
+
+  it 'loads questions as a hash' do
+    expect(questionnaire_data.questions).to be_a(Hash)
+  end
+
+  it 'loads answers within questions with symbolized keys' do
+    answers = yaml_data.dig('test', 'test', 'questions', 'one_from_many', 'answers')
+    answers.symbolize_keys!
+    expect(questionnaire_data.questions.dig(:one_from_many, :answers)).to eq(answers)
+  end
+
+  it 'loads correct answers within questions' do
+    correct_answers = yaml_data.dig('test', 'test', 'questions', 'one_from_many', 'correct_answers')
+    expect(questionnaire_data.questions.dig(:one_from_many, :correct_answers)).to eq(correct_answers)
+  end
+end

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -1,28 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Questionnaire, type: :model do
-  let(:yaml_data) { data_from_file('questionnaires/test.yml') }
   let(:questionnaire) { described_class.find_by!(name: :test, training_module: :test) }
-
-  it 'loads basic method' do
-    expect(questionnaire.heading).to eq(yaml_data.dig('test', 'test', 'heading'))
-    expect(questionnaire.content).to eq(yaml_data.dig('test', 'test', 'content'))
-  end
-
-  it 'loads questions as a hash' do
-    expect(questionnaire.questions).to be_a(Hash)
-  end
-
-  it 'loads answers within questions with symbolized keys' do
-    answers = yaml_data.dig('test', 'test', 'questions', 'one_from_many', 'answers')
-    answers.symbolize_keys!
-    expect(questionnaire.questions.dig(:one_from_many, :answers)).to eq(answers)
-  end
-
-  it 'loads correct answers within questions' do
-    correct_answers = yaml_data.dig('test', 'test', 'questions', 'one_from_many', 'correct_answers')
-    expect(questionnaire.questions.dig(:one_from_many, :correct_answers)).to eq(correct_answers)
-  end
 
   it 'is associated with matching module item' do
     module_item = ModuleItem.find_by(training_module: :test, name: :test)

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Questionnaire, type: :model do
   let(:yaml_data) { data_from_file('questionnaires/test.yml') }
-  let(:questionnaire) { described_class.find_by(name: :test, training_module: :test) }
+  let(:questionnaire) { described_class.find_by!(name: :test, training_module: :test) }
 
   it 'loads basic method' do
     expect(questionnaire.heading).to eq(yaml_data.dig('test', 'test', 'heading'))
@@ -27,5 +27,85 @@ RSpec.describe Questionnaire, type: :model do
   it 'is associated with matching module item' do
     module_item = ModuleItem.find_by(training_module: :test, name: :test)
     expect(questionnaire.module_item).to eq(module_item)
+  end
+
+  context 'with zero required_percentage_correct' do
+    before do
+      questionnaire.required_percentage_correct = 0
+    end
+
+    it 'is valid' do
+      expect(questionnaire).to be_valid
+    end
+  end
+
+  context 'with required_percentage_correct set' do
+    before do
+      questionnaire.required_percentage_correct = 100
+    end
+
+    it 'is invalid' do
+      expect(questionnaire).to be_invalid
+    end
+  end
+
+  context 'with required_percentage_correct not set and all answers correct' do
+    before do
+      questionnaire.required_percentage_correct = nil
+      questionnaire.questions.each do |question, data|
+        questionnaire.send("#{question}=", data[:correct_answers])
+      end
+    end
+
+    it 'is valid' do
+      expect(questionnaire).to be_valid
+    end
+  end
+
+  context 'with a question correct and required_percentage_correct not set' do
+    before do
+      questionnaire.required_percentage_correct = nil
+      question, data = questionnaire.questions.first
+      questionnaire.send("#{question}=", data[:correct_answers])
+    end
+
+    it 'is valid' do
+      expect(questionnaire).to be_invalid
+    end
+  end
+
+  context 'with a question correct and below required_percentage_correct threshold' do
+    before do
+      questionnaire.required_percentage_correct = 1
+      question, data = questionnaire.questions.first
+      questionnaire.send("#{question}=", data[:correct_answers])
+    end
+
+    it 'is valid' do
+      expect(questionnaire).to be_valid
+    end
+  end
+
+  context 'with a question correct and above required_percentage_correct threshold' do
+    before do
+      questionnaire.required_percentage_correct = 99
+      question, data = questionnaire.questions.first
+      questionnaire.send("#{question}=", data[:correct_answers])
+    end
+
+    it 'is valid' do
+      expect(questionnaire).to be_invalid
+    end
+  end
+
+  context 'with required_percentage_correct not set and no correct answers' do
+    before do
+      questionnaire.required_percentage_correct = nil
+      questionnaire.questions.each_value { |question| question.delete(:correct_answers) }
+    end
+
+    it 'is valid' do
+      expect(questionnaire).to be_valid
+    end
   end
 end

--- a/spec/models/user_answer_spec.rb
+++ b/spec/models/user_answer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe UserAnswer, type: :model do
   let(:user_answer) { create :user_answer }
 
   # Testing this association to check ActiveHash associations are working
-  it 'is associated with a questionnaire' do
-    expect(user_answer.questionnaire).to be_a(Questionnaire)
+  it 'is associated with a questionnaire data instance' do
+    expect(user_answer.questionnaire_data).to be_a(QuestionnaireData)
   end
 end

--- a/spec/requests/questionnaires_spec.rb
+++ b/spec/requests/questionnaires_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Questionnaires', type: :request do
-  let(:questionnaire) { Questionnaire.find_by(name: :test, training_module: :test) }
+  let(:questionnaire) { Questionnaire.find_by!(name: :test, training_module: :test) }
   let(:user) { create(:user, :registered) }
 
   before do
@@ -73,7 +73,7 @@ RSpec.describe 'Questionnaires', type: :request do
     end
 
     context 'with an existing user answer' do
-      let!(:user_answer) { create :user_answer, user: user, questionnaire: questionnaire }
+      let!(:user_answer) { create :user_answer, user: user, questionnaire_id: questionnaire.id }
 
       it 'archives the existing user answer' do
         submit_questionnaire


### PR DESCRIPTION
[Jira ER_156](https://dfedigital.atlassian.net/browse/ER-156)

The questionnaire data can now take a field `require_percentage_correct` which sets the threshold which must be exceeded for a questionnaire submission to be valid. The questionnaire validation has been updated so that:

- if threshold is set and the percentage of correct answers is below the threshold, that the questionnaire is invalid
- if threshold is set and the percentage of correct answers equals or is above the threshold, that the questionnaire is valid
- if no threshold is set and correct answers are set, it is assumed that all questions must be answered correctly for the questionnaire to be valid
- if no threshold is set and no correct answers are set, it is assumed no question matching is needed (questionnaire always valid)

I came across a few problems working on this due to the way ActiveHash works. It basically stores the YAML data in a set of singleton instances. So a change to a questionnaire instance would be carried across to the next instance of the same questionnaire. To stop this happening I split questionnaire in two:
- `QuestionnaireData` is now the ActiveYaml object that holds the questionnaire data pulled from the YAML configuration in `/data/questionnaires`
- `Questionnaire` is an object that clones that data and allows it to be manipulated within a transaction without any changes polluting the next transaction.