### PR TITLE
Always seed demo user

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 # Seed data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 Seeder = Dibber::Seeder
 
-Seeder.seed(:user, name_method: :email) if ENV['DEMO_USER_PASSWORD'].present?
+Seeder.seed(:user, name_method: :email)
 
 puts Seeder.report # rubocop:disable Rails/Output

--- a/db/seeds/users.yml
+++ b/db/seeds/users.yml
@@ -1,7 +1,7 @@
 ---
-demo@example.com:
+user@example.com:
   first_name: Demo
   last_name: User
-  password: <%= ENV.fetch('DEMO_USER_PASSWORD', 'password') %>
+  password: <%= ENV.fetch('DEMO_USER_PASSWORD', Rails.application.credentials.user_seed_password) %>
   confirmed_at: <%= 1.minute.ago %>
   registration_complete: true


### PR DESCRIPTION
Working on ER-119, discovered that the demo user was no longer seeding when I ran `db:reset` due to the lack of an ENV var DEMO_USER_PASSWORD.  We will need a demo user for every environment created, so suggested reverting to using the seeded password existing in the credentials file for each environment (principle of least surprise).

This may also help with the issue in https://github.com/DFE-Digital/early-years-foundation-recovery/pull/77