### PR TITLE
Add formative assessment controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,13 @@ class ApplicationController < ActionController::Base
 
     redirect_to extra_registrations_path, notice: 'Please complete registration'
   end
+
+  def questionnaire_path(training_module, module_item)
+    case module_item.type
+    when 'formative_assessment'
+      training_module_formative_assessment_path(training_module, module_item.model)
+    else
+      training_module_questionnaire_path(training_module, module_item.model)
+    end
+  end
 end

--- a/app/controllers/content_pages_controller.rb
+++ b/app/controllers/content_pages_controller.rb
@@ -10,7 +10,7 @@ class ContentPagesController < ApplicationController
     @model = module_item.model
 
     if @model.is_a?(Questionnaire)
-      redirect_to training_module_questionnaire_path(training_module, @model)
+      redirect_to questionnaire_path(training_module, module_item)
     else
       render module_item.type
     end

--- a/app/controllers/formative_assessments_controller.rb
+++ b/app/controllers/formative_assessments_controller.rb
@@ -1,0 +1,75 @@
+class FormativeAssessmentsController < ApplicationController
+  before_action :authenticate_registered_user!
+
+  def show
+    existing_answers = existing_user_answers.pluck(:question, :answer)
+    populate_questionnaire(existing_answers.to_h.symbolize_keys) if existing_answers.present?
+  end
+
+  def update
+    archive_previous_user_answers
+    if questionnaire_params.values.all?(&:present?)
+      populate_questionnaire(questionnaire_params)
+      save_answers
+      flash[:alert] = nil
+    else
+      flash[:alert] = 'Please select an answer'
+    end
+    render :show, status: :unprocessable_entity
+  end
+
+private
+
+  def questionnaire
+    @questionnaire ||= Questionnaire.find_by!(name: params[:id], training_module: training_module)
+  end
+
+  def training_module
+    @training_module ||= params[:training_module_id]
+  end
+
+  def questionnaire_params
+    @questionnaire_params ||= params.require(:questionnaire).permit(permitted_methods)
+  end
+
+  # An attribute is permitted if it is defined in the questionnaire's YAML data
+  # Added complication because multi-choice questions need to be set as hash within `permit` call
+  # as they are submitted as an array within params
+  def permitted_methods
+    questionnaire.questions.map do |question, data|
+      data[:multi_select] ? { question => [] } : question
+    end
+  end
+
+  def populate_questionnaire(question_input)
+    return if question_input.empty?
+
+    questionnaire.questions.each_key do |question|
+      answer = [question_input[question]].flatten.select(&:present?)
+      questionnaire.send("#{question}=", answer)
+    end
+    questionnaire.submitted = true
+  end
+
+  def archive_previous_user_answers
+    existing_user_answers.update_all(archived: true)
+  end
+
+  def existing_user_answers
+    current_user.user_answers.not_archived.where(questionnaire_id: questionnaire.id)
+  end
+
+  def save_answers
+    questionnaire.questions.each do |question, data|
+      answer = questionnaire.send(question)
+      next if answer.empty?
+
+      current_user.user_answers.create!(
+        questionnaire_id: questionnaire.id,
+        question: question,
+        answer: answer,
+        correct: answer == data[:correct_answers],
+      )
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,11 +31,11 @@ module ApplicationHelper
     )
   end
 
-  def link_to_next_module_item(module_item)
+  def link_to_next_module_item(module_item, link_args = {})
     if module_item.next_item
-      link_to 'Next', training_module_content_page_path(module_item.training_module, module_item.next_item)
+      link_to 'Next', training_module_content_page_path(module_item.training_module, module_item.next_item), link_args
     else
-      link_to 'Finish', training_modules_path
+      link_to 'Finish', training_modules_path, link_args
     end
   end
 

--- a/app/views/formative_assessments/_assessment_banner.html.slim
+++ b/app/views/formative_assessments/_assessment_banner.html.slim
@@ -1,0 +1,12 @@
+div class= "govuk-notification-banner #{'govuk-notification-banner--success' if questionnaire.valid?}" role='alert' aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+  .govuk-notification-banner__header
+    h2.govuk-notification-banner__title id= "govuk-notification-banner-title"
+      = @questionnaire.valid? ? "That's right" : "That's not quite right"
+
+  .govuk-notification-banner__content
+    h3.govuk-notification-banner__heading
+      - if questionnaire.errors.has_key?(question.to_s)
+        = questionnaire.questions.dig(question.to_sym, :assessment_fail_summary) || questionnaire.questions.dig(question.to_sym, :assessment_summary)
+      - else
+        = questionnaire.questions.dig(question.to_sym, :assessment_summary)
+

--- a/app/views/formative_assessments/show.html.slim
+++ b/app/views/formative_assessments/show.html.slim
@@ -1,0 +1,30 @@
+h1=@questionnaire.heading
+p=@questionnaire.content
+
+= form_with model: @questionnaire, url: training_module_formative_assessment_path(@training_module, @questionnaire), method: :patch do |form|
+  - @questionnaire.questions.each do |question, data|
+    p= data[:label]
+    p
+      - collection_method = data[:multi_select] ? :collection_check_boxes : :collection_radio_buttons
+      = form.send(collection_method, question, data[:answers], :first, :last) do |input|
+        p
+          - if data[:multi_select]
+            /
+              | Checkbox method is not automatically detecting correct checked status from questionnaire directly
+              | so have to set checked directly
+            = input.check_box(checked: @questionnaire.send(question)&.include?(input.value.to_s))
+          - else
+            = input.radio_button(checked: @questionnaire.send(question)&.include?(input.value.to_s))
+          = input.label
+
+    = render('assessment_banner', questionnaire: @questionnaire, question: question) if @questionnaire.send(question).present?
+
+  hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-4"
+  .govuk-grid-row
+    .govuk-grid-column-one-half
+      = link_to_previous_module_item(@questionnaire.module_item, class: "govuk-button govuk-button--secondary")
+    div class="govuk-grid-column-one-half govuk-!-text-align-right"
+      - if @questionnaire.vvvvvvvvvvsubmitted
+        = link_to_next_module_item(@questionnaire.module_item, class: "govuk-button")
+      - else
+        = submit_tag "Next", class: "govuk-button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   resources :modules, only: [:index], as: :training_modules, controller: :training_modules do
     resources :content_pages, only: %i[index show]
     resources :questionnaires, only: %i[show update]
+    resources :formative_assessments, only: %i[show update]
   end
 
   resources :static, only: :show

--- a/data/modules/test.yml
+++ b/data/modules/test.yml
@@ -1,6 +1,8 @@
 ---
 test:
   test:
+    type: questionnaire
+  formative_assessment:
     type: formative_assessment
   basic:
     type: text_page

--- a/data/questionnaires/one.yml
+++ b/data/questionnaires/one.yml
@@ -8,6 +8,8 @@ one:
       like_stuff:
         multi_select: false
         label: Do you like stuff
+        assessment_summary: Hey! You like stuff
+        assessment_fail_summary: You should like stuff
         answers:
           "yes": "Yes" # Set as string as YAML parses yes as true
           "no": "No" # Set as string as YAML parses no as false
@@ -20,6 +22,7 @@ one:
       who_likes_stuff:
         multi_select: true
         label: Who likes stuff
+        assessment_summary: Stuffy people and people who do stuffing don't like stuff.
         answers:
           stuffy_people: Stuffy people
           everybody: Everybody

--- a/data/questionnaires/test.yml
+++ b/data/questionnaires/test.yml
@@ -7,6 +7,8 @@ test:
       one_from_many:
         multi_select: false
         label: Select one from many
+        assessment_summary: Passed!
+        assessment_fail_summary: Failed
         answers:
           one: One
           two: Two
@@ -16,9 +18,25 @@ test:
       many_from_many:
         multi_select: true
         label: Select all the answers
+        assessment_summary: Completed
         answers:
           one: One
           two: Two
         correct_answers:
           - one
           - two
+  formative_assessment:
+    heading: A formative assessment
+    content: It has just one question
+    questions:
+      favourite_colour:
+        multi_select: false
+        label: What is your favourite colour
+        assessment_summary: Thank you for choosing a colour
+        assessment_fail_summary: Failed. That is not the answer we wanted
+        answers:
+          red: Red
+          green: Green
+          blue: Blue
+        correct_answers:
+          - blue

--- a/spec/requests/content_pages_spec.rb
+++ b/spec/requests/content_pages_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'ContentPages', type: :request do
 
       it 'redirects to questionnaire controller' do
         get training_module_content_page_path(:test, module_item)
-        expect(response).to redirect_to(training_module_questionnaire_path(:test, module_item.model))
+        expect(response).to redirect_to(training_module_formative_assessment_path(:test, module_item.model))
       end
     end
   end

--- a/spec/requests/formative_assessments_spec.rb
+++ b/spec/requests/formative_assessments_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe 'FormativeAssessments', type: :request do
+  let(:module_item) { ModuleItem.find_by(type: :formative_assessment, training_module: :test) }
+  let(:questionnaire_data) { module_item.model }
+  let(:user) { create(:user, :registered) }
+
+  before do
+    sign_in user
+  end
+
+  describe 'GET /modules/:training_module_id/formative_assessments/:id' do
+    subject(:show_view) { get training_module_formative_assessment_path(:test, questionnaire_data) }
+
+    it 'returns http success' do
+      show_view
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'does not display assessment summary' do
+      show_view
+      expect(response.body).not_to include(questionnaire_data.questions.dig(:favourite_colour, :assessment_summary))
+    end
+
+    context 'with existing correct answers' do
+      before do
+        user.user_answers.create(
+          questionnaire_id: questionnaire_data.id,
+          question: :favourite_colour,
+          answer: questionnaire_data.questions.dig(:favourite_colour, :correct_answers),
+        )
+      end
+
+      it 'displays the assessment summary' do
+        show_view
+        expect(response.body).to include(questionnaire_data.questions.dig(:favourite_colour, :assessment_summary))
+      end
+    end
+  end
+
+  describe 'PATCH /modules/:training_module_id/formative_assessments/:id' do
+    subject(:submit_questionnaire) do
+      patch training_module_formative_assessment_path(:test, questionnaire_data), params: { questionnaire: answers }
+    end
+
+    let(:answers) do
+      { favourite_colour: questionnaire_data.questions.dig(:favourite_colour, :correct_answers).first }
+    end
+
+    it 'renders the current page' do
+      submit_questionnaire
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'displays the assessment summary' do
+      submit_questionnaire
+      expect(response.body).to include(questionnaire_data.questions.dig(:favourite_colour, :assessment_summary))
+    end
+
+    it 'saves the answer' do
+      expect { submit_questionnaire }.to change(UserAnswer, :count).by(1)
+    end
+
+    context 'when failure' do
+      let(:answers) do
+        { favourite_colour: :incorrect }
+      end
+
+      it 'displays the assessment fail summary' do
+        submit_questionnaire
+        expect(response.body).to include(questionnaire_data.questions.dig(:favourite_colour, :assessment_fail_summary))
+      end
+    end
+
+    context 'when nothing has been selected' do
+      let(:answers) do
+        { favourite_colour: '' }
+      end
+
+      it 'displays a message asking the user to make an input' do
+        submit_questionnaire
+        expect(response.body).to include('Please select an answer')
+      end
+
+      it 'does not save the answer' do
+        expect { submit_questionnaire }.not_to change(UserAnswer, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/questionnaires_spec.rb
+++ b/spec/requests/questionnaires_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Questionnaires', type: :request do
     sign_in user
   end
 
-  describe 'GET /questionnaires/:id' do
+  describe 'GET /modules/:training_module_id/questionnaires/:id' do
     it 'returns http success' do
       get training_module_questionnaire_path(:test, questionnaire)
       expect(response).to have_http_status(:success)
@@ -26,7 +26,7 @@ RSpec.describe 'Questionnaires', type: :request do
     end
   end
 
-  describe 'PATCH /questionaires/:id' do
+  describe 'PATCH /modules/:training_module_id/questionaires/:id' do
     subject(:submit_questionnaire) do
       patch training_module_questionnaire_path(:test, questionnaire), params: { questionnaire: answers }
     end


### PR DESCRIPTION
Allows formative assessment to be handled differently to other questionnaires

[JIRA ER-153](https://dfedigital.atlassian.net/browse/ER-153)

A questionnaire can be defined as a formative assessment by setting it's type as `:formative_assessment` in `data/modules/<module_name>.yml`. The questionnaire will then be handled by the formative assessments controller. This has the following behaviour:

## Acceptance criteria

- If a user visits a formative assessment and they have no stored answers - they will be presented with a blank form
- If a user visits a  formative assessment and they have stored answers - the form will include the matching result box
- When a user arrives on a blank form page and they enter data, clicking Next will submit the form and display the results.
- Users will not be able to re-submit answers. Therefore, on a page showing a result box, clicking Next will take them to the next page.
- However, if a user submits a blank form a message will appear asking them to select an answer. They will not be able to proceed to the next page until they have submitted an answer. A blank submission should not be stored against the user.