### PR TITLE
Simplify asset pipeline bootstrapping in dev

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
+web: bin/rails server -b 0.0.0.0 -p 3000
 js: yarn; yarn build --watch
 css: yarn build:css --watch
-web: bin/rails server -b 0.0.0.0 -p 3000

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: bin/rails server -b 0.0.0.0 -p 3000
-js: yarn && yarn build --watch
+js: yarn; yarn build --watch
 css: yarn build:css --watch
+web: bin/rails server -b 0.0.0.0 -p 3000

--- a/README.md
+++ b/README.md
@@ -4,9 +4,20 @@
 
 ## Getting Started
 
-1. Clone the repository. This is a Rails 7 application using [the DfE template][rails-template]
-2. Obtain the master keys. Optionally create `.env` to override default variables.
-3. Run! (*running locally in the production rails environment requires self-signed certificates*)
+1. Clone the repository
+
+  This is a Rails 7 application using the [DfE template][rails-template].
+
+2. Obtain the master keys
+
+  Optionally create `.env` to override or set default variables like `DATABASE_URL`.
+
+3. Start the server
+
+  - `bin/dev` *(requires a running database server)*
+  - `bin/docker-dev` if using [Docker][docker]
+
+  NB: The initial two runs of these commands will bootstrap the asset pipeline dependencies.
 
 ## Useful Links
 
@@ -42,6 +53,10 @@ Use `bin/dev` to start the process workers (watching for changes to asset files)
 Use `bin/rspec` to run the test suite under `/spec`.
 Rails system specs use RackTest only for efficiency.
 
+**Production**
+
+Running locally in the production rails environment requires generating a self-signed certificate. Use `bin/docker-certs`
+
 **UI Framework**
 
 > Gemfile group :ui
@@ -67,6 +82,7 @@ These commands help maintain your containerised workspace:
     generated inside containers are created by *root*
 - `bin/docker-down` stop any active services
 - `bin/docker-prune` purge project containers, volumes and images
+- `bin/docker-dev-restart` restarts the running server
 
 The commands run common tasks inside containers:
 
@@ -183,4 +199,4 @@ or in the UK Government digital slack workspace in the `#govuk-notify` channel.
 [ci-workflow]: https://github.com/DFE-Digital/early-years-foundation-recovery/actions/workflows/ci.yml
 [notify]: https://www.notifications.service.gov.uk
 [figma]: https://www.figma.com/file/FGW1NJJwnYRqoZ2DV0l5wW/Training-content?node-id=1%3A19
-
+[docker]: https://www.docker.com

--- a/README.md
+++ b/README.md
@@ -87,19 +87,22 @@ These commands help maintain your containerised workspace:
 The commands run common tasks inside containers:
 
 - `bin/docker-dev` starts `Procfile.dev`, containerised equivalent of `bin/dev`,
-    using the `docker-compose.dev.yml` override
+    using the `docker-compose.dev.yml` override.
+    Additionally, it will install bundle and yarn dependencies.
 - `bin/docker-rails db:seed` populates the containerised postgres database
 - `bin/docker-rails console` drops into a running development environment or starts one,
     containerised equivalent of `bin/rails console`
 - `bin/docker-rspec -f doc` runs the test suite with optional arguments, containerised
     equivalent of `bin/rspec`
-- `bin/docker-qa` runs the browser tests against a running production application, a containerised equivalent of `bin/qa`
+- `bin/docker-qa` runs the browser tests against a running production application,
+    a containerised equivalent of `bin/qa`
 
 These commands can be used to debug problems:
 
 - `docker ps` lists all active **Docker** processes
 - `docker system prune` tidies up your system
-- `docker-compose -f docker-compose.yml -f docker-compose.<FILE>.yml --project-name recovery run --rm app`  can help identify why the application is not running in either the `dev`, `test`, or `qa` contexts
+- `docker-compose -f docker-compose.yml -f docker-compose.<FILE>.yml --project-name recovery run --rm app`
+    can help identify why the application is not running in either the `dev`, `test`, or `qa` contexts
 - `BASE_URL=https://app:3000 docker-compose -f docker-compose.yml -f docker-compose.qa.yml --project-name recovery up app` debug the UAT tests
 
 
@@ -119,7 +122,8 @@ These commands can be used to debug problems:
 
 ## Quality Assurance
 
-The UI/UA test suite can be run against any site. A production-like application is available as a composed Docker service for local development. To run a self-signed certificate must first be generated.
+The UI/UA test suite can be run against any site. A production-like application is available as a composed Docker service for local development.
+To run a self-signed certificate must first be generated.
 
 1. `./bin/docker-certs` (Mac users can trust the certificate in [Keychain Access](https://support.apple.com/en-gb/guide/keychain-access))
 2. `./bin/docker-qa` (this will build and bring up the application)

--- a/bin/docker-dev-restart
+++ b/bin/docker-dev-restart
@@ -1,0 +1,5 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+set -e
+
+docker exec -it recovery_dev touch ./tmp/restart.txt

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,11 +11,6 @@ then
     bundle
   fi
 
-  if [ ! -d "node_modules" ]; then
-    yarn
-    bundle exec rails assets:precompile
-  fi
-
   rm -f tmp/pids/server.pid
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,6 +11,10 @@ then
     bundle
   fi
 
+  if [ ! -d "node_modules" ]; then
+    yarn install
+  fi
+
   rm -f tmp/pids/server.pid
 fi
 


### PR DESCRIPTION
Bootstrapping assets was not working as intended for content designers and an easy way to restart the server was needed. 

- remove unnecessary asset compilation from entrypoint which failed because the preceding yarn process forked
- add convenience script to restart the dev server in docker
- update README