### PR TITLE
Comment out "labeler" match rule for "deployed"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,6 +14,6 @@ frontend:
 - app/javascript/*.js
 
 # Disabled as otherwise manually added labels are removed if they do not match.
-#
+# (edit to test)
 # deployed:
 # - ui/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,5 +13,7 @@ frontend:
 - app/assets/stylesheets/*
 - app/javascript/*.js
 
-deployed:
-- ui/**/*
+# Disabled as otherwise manually added labels are removed if they do not match.
+#
+# deployed:
+# - ui/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,6 +14,6 @@ frontend:
 - app/javascript/*.js
 
 # Disabled as otherwise manually added labels are removed if they do not match.
-# (edit to test)
+#
 # deployed:
 # - ui/**/*


### PR DESCRIPTION
This will prevent the `labeler` action from removing `deployed` from open PRs.
Demonstrated below in the conversation.