### PR TITLE
Govspeak styling using the SCSS from Reform

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,11 +1,5 @@
 @import "govuk-frontend/govuk/all";
-
-/*
-https://github.com/alphagov/govuk_publishing_components/blob/main/docs/install-and-use.md
-@import "govuk_publishing_components/govuk_frontend_support";
-@import "govuk_publishing_components/component_support";
-@import "govuk_publishing_components/components/govspeak";
-*/
+@import "./govspeak";
 
 .debug_dump {
   background: beige;

--- a/app/assets/stylesheets/govspeak.scss
+++ b/app/assets/stylesheets/govspeak.scss
@@ -1,0 +1,38 @@
+// vendor original
+@import "./govspeak/_advisory";
+@import "./govspeak/attachment";
+@import "./govspeak/button";
+@import "./govspeak/call-to-action";
+@import "./govspeak/charts";
+@import "./govspeak/contact";
+@import "./govspeak/example";
+@import "./govspeak/footnotes";
+@import "./govspeak/form-download";
+@import "./govspeak/fraction";
+@import "./govspeak/highlight-answer";
+@import "./govspeak/images";
+@import "./govspeak/information-callout";
+@import "./govspeak/legislative-list";
+@import "./govspeak/media-player";
+@import "./govspeak/place";
+@import "./govspeak/stat-headline";
+@import "./govspeak/steps";
+@import "./govspeak/summary";
+@import "./govspeak/tables";
+@import "./govspeak/typography";
+@import "./govspeak/warning-callout";
+
+// custom overrides
+@import "./govspeak/overrides/accordion";
+@import "./govspeak/overrides/call-to-action";
+@import "./govspeak/overrides/contents-list";
+@import "./govspeak/overrides/highlights";
+@import "./govspeak/overrides/quote";
+@import "./govspeak/overrides/tables";
+
+.gem-c-govspeak {
+  &.direction-rtl {
+    direction: rtl;
+    text-align: start;
+  }
+}

--- a/app/assets/stylesheets/govspeak/_advisory.scss
+++ b/app/assets/stylesheets/govspeak/_advisory.scss
@@ -1,0 +1,33 @@
+$info-background: #d5e8f3;
+$high-alert-border: #cc0000;
+
+.gem-c-govspeak .advisory {
+  background-image: image-url("../images/icon-important.svg");
+  background-repeat: no-repeat;
+  background-size: 30px 30px;
+  background-position: 98% center;
+  background-color: $info-background;
+  line-height: 1.3em;
+  margin: 0 -1em 1em;
+  padding: govuk-spacing(3) govuk-spacing(8) govuk-spacing(3) govuk-spacing(3);
+  text-align: left;
+
+  p {
+    margin: 0 .75em 0 0;
+    min-height: 1.75em;
+    padding-right: 3em;
+  }
+
+  strong {
+    font-weight: 400;
+  }
+
+  &.high-alert {
+    background-color: govuk-colour("light-grey", $legacy: "grey-3");
+    border: 1px solid $high-alert-border;
+  }
+
+  @include govuk-media-query($until: tablet) {
+    margin: 0 0 1em;
+  }
+}

--- a/app/assets/stylesheets/govspeak/_attachment.scss
+++ b/app/assets/stylesheets/govspeak/_attachment.scss
@@ -1,0 +1,127 @@
+// Govspeak attachment
+// https://components.publishing.service.gov.uk/component-guide/govspeak/block_attachments
+//
+// Support:
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+// stylelint-disable max-nesting-depth
+
+.gem-c-govspeak {
+
+  // Scope attachment and attachment-link component styles to gem-c-govspeak
+  @import "./helpers/attachment-link";
+  @import "./helpers/attachment";
+
+  // This block is duplicated from Whitehall as a transitional step, see the
+  // commit message for 2d893c10ee3f2cab27162b9aba38b12379a71d07 before making
+  // changes, original version:
+  // https://github.com/alphagov/whitehall/blob/master/app/assets/stylesheets/frontend/helpers/_attachment.scss
+  $thumbnail-width: 99px;
+
+  .attachment {
+    position: relative;
+    margin: govuk-spacing(6) 0;
+    padding: govuk-spacing(3) 0 0 ($thumbnail-width + govuk-spacing(6));
+    @include govuk-clearfix;
+
+    &:first-child {
+      margin-top: 0;
+      padding-top: 0;
+    }
+
+    .attachment-thumb {
+      position: relative;
+      float: left;
+      margin-top: $govuk-border-width;
+      margin-left: -($thumbnail-width + govuk-spacing(6) - $govuk-border-width);
+      padding-bottom: govuk-spacing(3);
+
+      img {
+        display: block;
+        width: $thumbnail-width;
+        height: 140px;
+        background: govuk-colour("white");
+        outline: $govuk-border-width solid transparentize(govuk-colour("black"), .9);
+
+        @include govuk-if-ie8 {
+          // IE8 incorrectly asserts the "max-width: 100%" rule to be 0
+          // because of the collapsed width on its floating container
+          // Reset the max-width so that thumbnails render at the specified
+          // width above.
+          // http://www.456bereastreet.com/archive/201202/using_max-width_on_images_can_make_them_disappear_in_ie8/
+          max-width: none;
+          border: $govuk-border-width solid govuk-colour("mid-grey", $legacy: "grey-3");
+        }
+
+        box-shadow: 0 2px 2px rgba(govuk-colour("black"), .4);
+      }
+    }
+
+    .attachment-details {
+      h2 {
+        @include govuk-font($size: 27);
+        margin: 0;
+      }
+
+      p {
+        margin: govuk-spacing(2) 0;
+      }
+
+      .metadata {
+        @include govuk-font($size: 14);
+      }
+
+      .url {
+        word-break: break-word;
+        word-wrap: break-word;
+      }
+
+      .changed,
+      .references,
+      .unnumbered-paper {
+        display: block;
+      }
+
+      .preview,
+      .download {
+        @include govuk-font($size: 19);
+
+        strong {
+          font-weight: bold;
+        }
+      }
+
+      .preview {
+        padding-right: govuk-spacing(3);
+      }
+
+      .opendocument-help {
+        @include govuk-font($size: 14);
+      }
+
+      .accessibility-warning {
+        h2 {
+          @include govuk-font($size: 14);
+          margin: 0;
+        }
+        word-break: break-word;
+        word-wrap: break-word;
+      }
+
+      .js-hidden {
+        display: none;
+      }
+    }
+  }
+
+  &.direction-rtl .attachment {
+    padding: govuk-spacing(3) ($thumbnail-width + govuk-spacing(6)) 0 0;
+
+    .attachment-thumb {
+      float: right;
+      margin-left: 0;
+      margin-right: (($thumbnail-width * -1) - govuk-spacing(3));
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/_button.scss
+++ b/app/assets/stylesheets/govspeak/_button.scss
@@ -1,0 +1,12 @@
+@import "govuk-frontend/govuk/components/button/button";
+
+// stylelint-disable scss/at-extend-no-missing-placeholder
+.gem-c-govspeak {
+  .gem-c-button {
+    @extend .govuk-button;
+  }
+
+  .govuk-button--start {
+    @extend .govuk-button--start;
+  }
+}

--- a/app/assets/stylesheets/govspeak/_call-to-action.scss
+++ b/app/assets/stylesheets/govspeak/_call-to-action.scss
@@ -1,0 +1,25 @@
+// Govspeak call to action
+// https://components.publishing.service.gov.uk/component-guide/govspeak/call_to_action
+//
+// Support:
+//
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+.gem-c-govspeak {
+  .call-to-action {
+    margin: 2em 0;
+    background-color: govuk-colour("light-grey", $legacy: "grey-3");
+    padding: 2em;
+
+    &:first-child {
+      margin-top: 0;
+    }
+
+    p:last-child,
+    ul:last-child,
+    ol:last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/_charts.scss
+++ b/app/assets/stylesheets/govspeak/_charts.scss
@@ -1,0 +1,297 @@
+// Govspeak charts
+// https://components.publishing.service.gov.uk/component-guide/govspeak/charts
+// Uses Magna Charta (https://github.com/alphagov/magna-charta)
+//
+// Support:
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+// adapted from magna-charta example stylesheet
+// https://github.com/alphagov/magna-charta/blob/master/demo/stylesheets/magna-charta.css
+
+// stylelint-disable max-nesting-depth
+
+.gem-c-govspeak {
+  // DEFAULT CHART STYLES
+
+  $label-width: 40%; // Horizontal width taken up by the bar labels
+  $label-align: right; // Label alignment
+  $base-unit: 16px; // For font sizes and related spacing
+  $compact-font-size: 12px; // For the 'compact' bar style
+  $bar-padding: 8px; // The padding between the bar values and the edge of the bar
+  $bar-spacing: 5px; // The spacing around the bars
+  $stack-spacing: 1px; // For stacked bars, the spacing between each stack in a bar
+  $caption-side: top; // Caption alignment. Top or bottom.
+  $key-width: 160px; // Only used by IE. Other browsers get smallest width that fits content
+
+  // CHART COLOUR SCHEME
+
+  $chart-border: govuk-colour("white"); // Chart border colour
+  $key-border: govuk-colour("white"); // Key border colour
+  $bar-colours: govuk-colour("blue"), govuk-colour("turquoise"), govuk-colour("green"), govuk-colour("light-green"), govuk-colour("yellow"), govuk-colour("orange"), govuk-colour("red"), govuk-colour("bright-purple", $legacy: "bright-red");
+  $bar-text-colours: govuk-colour("white"), govuk-colour("black"), govuk-colour("white"), govuk-colour("black"), govuk-colour("black"), govuk-colour("black"), govuk-colour("white"), govuk-colour("white");
+  $bar-cell-colour: govuk-colour("black");
+  $bar-outdented-colour: govuk-colour("black");
+
+  // CHART STYLES
+  .mc-chart {
+    font-size: $base-unit;
+    display: table;
+    width: 100%;
+    border-spacing: 0 $bar-spacing;
+    border: 1px solid $chart-border;
+    padding: $base-unit 0;
+    position: relative;
+    margin-bottom: $base-unit;
+
+    // CAPTION STYLES
+    .mc-caption {
+      display: table-caption;
+      font-size: $base-unit;
+      text-align: center;
+      caption-side: $caption-side;
+      margin: $base-unit 0;
+    }
+
+    // KEY STYLES
+    .mc-thead {
+      background-color: govuk-colour("white");
+      display: table-header-group;
+      padding: $bar-spacing;
+      border: 1px solid $key-border;
+
+      .mc-th {
+        display: none; // Hide all header cells first
+      }
+
+      .mc-key-header {
+        display: block; // Show the header cells that form part of the key
+        margin-bottom: $bar-spacing;
+        margin-left: 100%;
+        padding-left: $bar-spacing;
+        border-left: $base-unit solid;
+        text-align: left;
+        font-weight: normal;
+        width: 100%;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+
+      // Key colours
+      @for $i from 0 to length($bar-colours) {
+        .mc-key-#{$i + 1} {
+          border-left-color: nth($bar-colours, $i + 1);
+        }
+      }
+    }
+
+    // Right and left aligned keys
+    &.right-key .mc-thead,
+    &.left-key .mc-thead {
+      position: absolute;
+      top: 100px;
+
+      .mc-key-header {
+        margin-left: 0;
+      }
+    }
+
+    &.right-key .mc-thead {
+      right: 26px;
+    }
+
+    &.left-key .mc-thead {
+      left: 26px;
+    }
+
+    // Hidden keys
+    &.no-key .mc-thead {
+      display: none;
+    }
+
+    // BAR STYLES
+    .mc-tbody {
+      display: table-row-group;
+
+      .mc-tr {
+        display: table-row;
+
+        // Bars and bar labels
+        .mc-bar-cell,
+        .mc-key-cell {
+          padding-right: $bar-spacing;
+          margin-right: $stack-spacing;
+          box-sizing: border-box;
+          border: 0 solid;
+        }
+
+        // Bars
+        .mc-bar-cell {
+          display: block;
+          text-align: left;
+          padding: $bar-padding 0;
+          margin-bottom: 1px;
+          color: govuk-colour("white");
+          text-indent: $bar-padding;
+        }
+
+        // Bar colours
+        @for $i from 0 to length($bar-colours) {
+          .mc-bar-#{$i + 1} {
+            background-color: nth($bar-colours, $i + 1);
+            color: nth($bar-text-colours, $i + 1);
+          }
+        }
+
+        // Negative bars
+        .mc-bar-negative {
+          text-align: right;
+          padding-right: $bar-padding;
+        }
+
+        .mc-value-overflow {
+          text-indent: -99999px !important; // stylelint-disable-line declaration-no-important
+        }
+
+        // Bar labels
+        .mc-key-cell {
+          width: $label-width;
+          text-indent: 26px;
+          text-align: $label-align;
+          display: table-cell;
+          vertical-align: middle;
+        }
+      }
+    }
+
+    // STACKED CHARTS
+    &.mc-stacked {
+      .mc-stacked-header {
+        display: none; // Hide the header for the totals column
+      }
+
+      .mc-th:nth-last-child(2) {
+        margin-bottom: 0;
+      }
+
+      .mc-stacked-total {
+        padding: $bar-padding 0;
+        background-color: transparent !important; // stylelint-disable-line declaration-no-important
+        color: govuk-colour("black");
+        display: inline-block;
+        text-indent: 5px;
+      }
+
+      .mc-tbody .mc-bar-cell {
+        display: inline-block;
+      }
+    }
+
+    // COMPACT CHARTS
+    &.compact {
+      .mc-td.mc-bar-cell {
+        font-size: $compact-font-size;
+        text-indent: 2px;
+        padding: 0;
+      }
+    }
+
+    // Charts with multiple columns get different coloured bars
+    $len: length($bar-colours);
+
+    @for $i from 0 to $len {
+      .mc-tr .mc-td.mc-bar-cell.mc-bar-#{$i + 1} {
+        background-color: nth($bar-colours, $i + 1);
+      }
+
+      .mc-tr .mc-th.mc-key-#{$i + 1} {
+        border-left-color: nth($bar-colours, $i + 1);
+      }
+    }
+
+    .mc-td,
+    .mc-th {
+      padding: 0;
+      padding-right: $bar-spacing;
+      margin-right: $stack-spacing;
+      border: 0 solid;
+
+      &.mc-bar-cell {
+        display: block;
+        background-color: $bar-cell-colour; // Just for testing
+        text-align: left;
+        padding: $bar-padding 0;
+        margin-bottom: 1px;
+        color: govuk-colour("white");
+        text-indent: 4px;
+        line-height: 1.5;
+      }
+    }
+
+    .mc-bar-outdented {
+      span {
+        color: $bar-outdented-colour;
+      }
+    }
+
+    caption {
+      caption-side: $caption-side;
+    }
+
+    .mc-td.mc-key-cell {
+      width: $label-width;
+      text-indent: 26px;
+      text-align: $label-align;
+      display: table-cell;
+      vertical-align: middle;
+    }
+
+    // OUTDENTED BAR VALUES
+    &.mc-outdented {
+      .mc-tr {
+        .mc-bar-cell {
+          color: $bar-cell-colour;
+        }
+
+        .mc-bar-negative {
+          text-align: left;
+        }
+      }
+    }
+
+    &.mc-negative .mc-td.mc-key-cell {
+      padding-right: 25px;
+    }
+  }
+
+  .mc-outdented .mc-bar-cell.mc-bar-negative {
+    text-align: left;
+  }
+
+  .mc-toggle-button {
+    @extend %govuk-body-s;
+    border: 1px solid $govuk-border-colour;
+    color: $govuk-link-colour;
+    cursor: pointer;
+    margin: govuk-spacing(0);
+    padding: govuk-spacing(2);
+    background-color: govuk-colour("white");
+
+    &:focus {
+      @include govuk-focused-text;
+      background-color: $govuk-focus-colour;
+      border-color: transparent;
+    }
+  }
+
+  // Hides the original table
+  .mc-hidden,
+  .mc-hidden caption {
+    display: none;
+
+    // It's reapplied to captions because Firefox can't hide
+    // table captions unless it's applied directly to it. Go figure.
+  }
+}

--- a/app/assets/stylesheets/govspeak/_contact.scss
+++ b/app/assets/stylesheets/govspeak/_contact.scss
@@ -1,0 +1,51 @@
+// Govspeak contact
+// https://components.publishing.service.gov.uk/component-guide/govspeak/contact
+//
+// Support:
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+// stylelint-disable max-nesting-depth
+
+.gem-c-govspeak {
+  // .address is used by the `$A` markdown pattern
+  .address,
+  .contact {
+    border-left: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
+    padding-left: govuk-spacing(3);
+    margin-bottom: govuk-spacing(6);
+    margin-top: govuk-spacing(6);
+  }
+
+  .contact {
+    @include govuk-clearfix;
+    position: relative;
+
+    .content {
+      float: none;
+      width: 100%;
+
+      h3 {
+        @include govuk-font($size: 19, $weight: bold);
+        margin-bottom: 5px;
+      }
+
+      .email-url-number {
+        .email {
+          word-wrap: break-word;
+        }
+
+        span {
+          display: block;
+        }
+      }
+
+      .comments {
+        @include govuk-font($size: 16);
+        @include govuk-media-query($from: tablet) {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/_example.scss
+++ b/app/assets/stylesheets/govspeak/_example.scss
@@ -1,0 +1,25 @@
+// Govspeak example callout
+// https://components.publishing.service.gov.uk/component-guide/govspeak/example
+//
+// Support:
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+.gem-c-govspeak {
+  .example {
+    border-left: 10px solid govuk-colour("mid-grey", $legacy: "grey-3");
+    padding: 1em 0 1em 1em;
+    margin: 2em 0;
+
+    // Remove margin from the last element
+    p:last-child,
+    ul:last-child,
+    ol:last-child {
+      margin-bottom: 0;
+    }
+
+    strong {
+      display: block;
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/_footnotes.scss
+++ b/app/assets/stylesheets/govspeak/_footnotes.scss
@@ -1,0 +1,33 @@
+// Govspeak footnotes callout
+// https://components.publishing.service.gov.uk/component-guide/govspeak/footnotes
+//
+// Support:
+//
+// This appears to be built into kramdown, we're just applying styling to it.
+// https://kramdown.gettalong.org/syntax.html#footnotes
+//
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+// stylelint-disable max-nesting-depth
+
+.gem-c-govspeak {
+  .footnotes {
+    border-top: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
+    margin-top: govuk-spacing(6);
+    padding-top: govuk-spacing(2);
+
+    a {
+      overflow-wrap: break-word;
+    }
+
+    ol {
+      margin-top: 0;
+      padding-top: 0;
+
+      li p {
+        margin: 10px 0;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/_form-download.scss
+++ b/app/assets/stylesheets/govspeak/_form-download.scss
@@ -1,0 +1,21 @@
+.gem-c-govspeak .form-download {
+  padding: .25em 0;
+
+  @include govuk-media-query($until: tablet) {
+    margin: 1em 0 1.5em;
+  }
+
+  p {
+    padding-right: 3em;
+  }
+
+  a {
+    display: block;
+    font-weight: 600;
+    background-image: image-url("../images/icon-file-download.svg");
+    background-repeat: no-repeat;
+    background-size: 40px 40px;
+    min-height: 2.5em;
+    padding: 0 0 0 50px;
+  }
+}

--- a/app/assets/stylesheets/govspeak/_fraction.scss
+++ b/app/assets/stylesheets/govspeak/_fraction.scss
@@ -1,0 +1,22 @@
+// Govspeak fractions
+// https://components.publishing.service.gov.uk/component-guide/govspeak/image_fractions
+// https://components.publishing.service.gov.uk/component-guide/govspeak/text_fractions
+//
+// Support:
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✘
+
+.gem-c-govspeak {
+  .fraction {
+    sup,
+    sub {
+      @include govuk-font($size: 14);
+    }
+
+    img {
+      display: inline-block;
+      width: auto;
+      margin: 0 0 -5px;
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/_highlight-answer.scss
+++ b/app/assets/stylesheets/govspeak/_highlight-answer.scss
@@ -1,0 +1,44 @@
+// stylelint-disable max-nesting-depth
+
+$highlight-answer-bg-color: govuk-colour("green");
+$highlight-answer-color: govuk-colour("white");
+
+.gem-c-govspeak .highlight-answer {
+  background-color: $highlight-answer-bg-color;
+  color: $highlight-answer-color;
+  text-align: center;
+  padding: 1.75em .75em 1.25em;
+  margin: 0 -1em 1em;
+
+  p {
+    @include govuk-font($size: 24, $weight: bold);
+    color: $highlight-answer-color;
+
+    em {
+      @include govuk-font($size: 80, $weight: bold);
+      display: block;
+      padding-top: .1em;
+      color: $highlight-answer-color;
+    }
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+
+  @include govuk-media-query($until: tablet) {
+    margin: 0 0 1em;
+    @include govuk-font($size: 48);
+
+    p {
+      font-size: 1em;
+      line-height: inherit;
+
+      em {
+        font-size: 1em;
+        padding-top: 0;
+        display: inline;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/_images.scss
+++ b/app/assets/stylesheets/govspeak/_images.scss
@@ -1,0 +1,32 @@
+// Govspeak images
+//
+// Support:
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+.gem-c-govspeak {
+  img {
+    width: auto;
+    height: auto;
+    max-width: 100%;
+  }
+
+  figure {
+    width: 100%;
+    clear: both;
+    overflow: hidden;
+    padding: govuk-spacing(2) 0 0;
+
+    img {
+      display: inline;
+      text-align: center;
+      width: auto;
+      height: auto;
+      max-width: 100%;
+    }
+
+    figcaption {
+      @include govuk-font($size: 14);
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/_information-callout.scss
+++ b/app/assets/stylesheets/govspeak/_information-callout.scss
@@ -1,0 +1,22 @@
+// Govspeak information callout
+// https://components.publishing.service.gov.uk/component-guide/govspeak/information_callout
+//
+// Support:
+//
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+.gem-c-govspeak {
+  .info-notice {
+    border-left: 10px solid govuk-colour("mid-grey", $legacy: "grey-3");
+    padding: 1em 0 1em 1em;
+    margin: 2em 0;
+
+    // Remove margin from the last element
+    p:last-child,
+    ul:last-child,
+    ol:last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/_legislative-list.scss
+++ b/app/assets/stylesheets/govspeak/_legislative-list.scss
@@ -1,0 +1,26 @@
+// Govspeak legislative list
+// https://components.publishing.service.gov.uk/component-guide/govspeak/legislative_lists
+
+// Support:
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+.gem-c-govspeak {
+  .legislative-list {
+    list-style: none;
+    margin: 5px 0;
+
+    li {
+      margin: 5px 0;
+    }
+
+    p {
+      margin: 20px 0;
+    }
+
+    ol {
+      margin: govuk-spacing(2) 0 govuk-spacing(2) govuk-spacing(6);
+      list-style: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/_media-player.scss
+++ b/app/assets/stylesheets/govspeak/_media-player.scss
@@ -1,0 +1,27 @@
+// Govspeak media player
+// https://components.publishing.service.gov.uk/component-guide/govspeak/with_youtube_embed
+//
+// Support:
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+.gem-c-govspeak__youtube-video {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(2);
+  padding-top: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-bottom: 56.25%;
+}
+
+.gem-c-govspeak__youtube-video iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}

--- a/app/assets/stylesheets/govspeak/_place.scss
+++ b/app/assets/stylesheets/govspeak/_place.scss
@@ -1,0 +1,29 @@
+.gem-c-govspeak .place {
+  margin: 1.5em 0;
+  border-bottom: solid 1px govuk-colour("mid-grey", $legacy: "grey-2");
+  padding-bottom: 1.5em;
+
+  .address {
+    margin: 0;
+    padding: 0;
+    width: auto;
+    display: block;
+  }
+
+  .url {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .additional-information {
+    @include govuk-font($size: 16);
+
+    p {
+      margin: .25em 0;
+    }
+  }
+
+  @include govuk-media-query($until: tablet) {
+    margin: .75em 0;
+  }
+}

--- a/app/assets/stylesheets/govspeak/_stat-headline.scss
+++ b/app/assets/stylesheets/govspeak/_stat-headline.scss
@@ -1,0 +1,29 @@
+// Govspeak statistic headline
+// https://components.publishing.service.gov.uk/component-guide/govspeak/statistic_headlines
+//
+// Support:
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+.gem-c-govspeak {
+  .stat-headline {
+    margin-bottom: govuk-spacing(3);
+    margin-top: govuk-spacing(3);
+
+    @include govuk-media-query($from: tablet) {
+      margin-bottom: govuk-spacing(4);
+      margin-top: govuk-spacing(4);
+    }
+
+    p {
+      @include govuk-font($size: 19, $weight: bold);
+      margin: 0;
+    }
+
+    em {
+      @include govuk-font($size: 80, $weight: bold);
+      display: block;
+      margin: 3px 0 -5px;
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/_steps.scss
+++ b/app/assets/stylesheets/govspeak/_steps.scss
@@ -1,0 +1,22 @@
+.gem-c-govspeak .steps {
+  padding-left: 0;
+  margin-left: 0;
+  overflow: hidden;
+
+  > li {
+    background-position: 0 .87em;
+    background-repeat: no-repeat;
+    list-style-type: decimal;
+    margin-left: 0;
+    padding: .75em 0 .75em 2.5em;
+
+    @for $i from 1 through 30 {
+      &:nth-child(#{$i}) {
+        background-image: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 250 250' preserveAspectRatio='xMinYMin meet'%3E%3Cg%3E%3Ccircle r='50%25' cx='50%25' cy='50%25' class='circle-back'%3E%3C/circle%3E%3Ctext x='50%25' y='50%25' text-anchor='middle' dy='0.3em' font-family='nta,arial,sans-serif' font-size='8rem' fill='%23ffffff'%3E#{$i}%3C/text%3E%3C/g%3E%3C/svg%3E ");
+        background-repeat: no-repeat;
+        background-position: .2em .7em;
+        background-size: 1.4em 1.4em;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/_summary.scss
+++ b/app/assets/stylesheets/govspeak/_summary.scss
@@ -1,0 +1,24 @@
+.gem-c-govspeak .summary {
+  margin: 0 0 2em;
+  padding: 0;
+  color: $govuk-text-colour;
+
+  p {
+    @include govuk-font($size: 19);
+  }
+
+  @include govuk-media-query($until: tablet) {
+    margin: 0 0 2em;
+    padding: 0;
+  }
+
+  p,
+  h2 {
+    border: 0;
+    margin: 0 .75em 0 0;
+  }
+
+  h2 {
+    line-height: 1.35em;
+  }
+}

--- a/app/assets/stylesheets/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govspeak/_tables.scss
@@ -1,0 +1,40 @@
+// Govspeak tables
+// https://components.publishing.service.gov.uk/component-guide/govspeak/tables
+//
+// Support:
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+.gem-c-govspeak {
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    display: block;
+    margin: govuk-spacing(6) 0;
+    overflow-x: auto;
+    width: 100%;
+    @include govuk-font($size: 14);
+
+    caption {
+      text-align: left;
+      margin-bottom: .5em;
+    }
+
+    th,
+    td {
+      vertical-align: top;
+      padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
+      border-bottom: solid 1px govuk-colour("mid-grey", $legacy: "grey-2");
+    }
+
+    th {
+      @include govuk-font($size: 14, $weight: bold);
+      text-align: left;
+      color: $govuk-text-colour;
+    }
+
+    td small {
+      font-size: 1em;
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govspeak/_typography.scss
@@ -1,0 +1,100 @@
+@import "./helpers/markdown-typography";
+// Govspeak typography
+// https://components.publishing.service.gov.uk/component-guide/govspeak/heading_levels
+// https://components.publishing.service.gov.uk/component-guide/govspeak/lists
+// https://components.publishing.service.gov.uk/component-guide/govspeak/nested_lists
+// https://components.publishing.service.gov.uk/component-guide/govspeak/blockquote
+//
+// Support:
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+// stylelint-disable max-nesting-depth
+
+.gem-c-govspeak {
+  @include markdown-typography;
+
+  &.direction-rtl ol,
+  &.direction-rtl ul {
+    margin-left: 0;
+    margin-right: govuk-spacing(4);
+
+    a {
+      overflow-wrap: break-word;
+    }
+
+    ul,
+    ol {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  // Block quotes
+
+  blockquote {
+    padding: 0 0 0 govuk-spacing(4);
+    margin: 0;
+    border: 0;
+
+    @include govuk-media-query($from: desktop) {
+      margin: 0 0 0 (- govuk-spacing(6));
+    }
+
+    p {
+      padding-left: govuk-spacing(3);
+
+      @include govuk-media-query($from: tablet) {
+        padding-left: govuk-spacing(6);
+      }
+
+      &:before {
+        content: "\201C";
+        float: left;
+        clear: both;
+        margin-left: (- govuk-spacing(3));
+      }
+
+      &:last-child:after {
+        content: "\201D";
+      }
+    }
+  }
+
+  &.direction-rtl blockquote {
+    padding: 0 govuk-spacing(4) 0 0;
+
+    @include govuk-media-query($from: desktop) {
+      margin: 0 (- govuk-spacing(6)) 0 0;
+    }
+
+    p {
+      padding-right: govuk-spacing(3);
+      padding-left: 0;
+
+      @include govuk-media-query($from: tablet) {
+        padding-right: govuk-spacing(6);
+        padding-left: 0;
+      }
+
+      &:before {
+        content: "\201D";
+        float: right;
+        margin-right: (- govuk-spacing(3));
+        margin-left: 0;
+      }
+
+      &:last-child:after {
+        content: "\201C";
+      }
+    }
+  }
+
+  // Text styles
+
+  em,
+  i {
+    font-style: normal;
+    font-weight: inherit;
+  }
+}

--- a/app/assets/stylesheets/govspeak/_warning-callout.scss
+++ b/app/assets/stylesheets/govspeak/_warning-callout.scss
@@ -1,0 +1,36 @@
+// Govspeak warning callout
+// https://components.publishing.service.gov.uk/component-guide/govspeak/warning_callout
+//
+// Support:
+//
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+.gem-c-govspeak {
+  .help-notice {
+    $icon-size: 34px;
+    $line-height-mobile: 20px;
+    $line-height-tablet: 25px;
+
+    margin: 2em 0;
+
+    // Add '!' icon
+    background-image: image-url("../images/icon-important.svg");
+    background-size: $icon-size $icon-size;
+    background-repeat: no-repeat;
+    min-height: $icon-size;
+    padding-left: $icon-size;
+
+    // Center the icon around the baseline
+    padding-top: ($icon-size - $line-height-mobile) / 2;
+
+    @include govuk-media-query($from: tablet) {
+      padding-top: ($icon-size - $line-height-tablet) / 2;
+    }
+
+    p {
+      @include govuk-font($size: 19, $weight: bold);
+      margin-left: 1em;
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/helpers/_attachment-link.scss
+++ b/app/assets/stylesheets/govspeak/helpers/_attachment-link.scss
@@ -1,0 +1,4 @@
+.gem-c-attachment-link__abbr {
+  text-decoration: none;
+  cursor: help;
+}

--- a/app/assets/stylesheets/govspeak/helpers/_attachment.scss
+++ b/app/assets/stylesheets/govspeak/helpers/_attachment.scss
@@ -1,0 +1,76 @@
+$thumbnail-width: 99px;
+$thumbnail-height: 140px;
+$thumbnail-border-width: 5px;
+$thumbnail-background: govuk-colour("white");
+$thumbnail-border-colour: rgba(11, 12, 12, .1);
+$thumbnail-shadow-colour: rgba(11, 12, 12, .4);
+$thumbnail-shadow-width: 0 2px 2px;
+$thumbnail-icon-border-colour: govuk-colour("mid-grey", $legacy: "grey-3");
+
+.gem-c-attachment {
+  @include govuk-font(19);
+  @include govuk-clearfix;
+  position: relative;
+
+  .govuk-details__summary {
+    @include govuk-font($size: 14);
+  }
+}
+
+.gem-c-attachment__thumbnail {
+  position: relative;
+  width: auto;
+  margin-right: govuk-spacing(5);
+  margin-bottom: govuk-spacing(3);
+  padding: $thumbnail-border-width;
+  float: left;
+}
+
+.gem-c-attachment__thumbnail-image {
+  display: block;
+  width: auto; // for IE8
+  max-width: $thumbnail-width;
+  height: $thumbnail-height;
+  border: $thumbnail-border-colour; // for IE9 & IE10
+  outline: $thumbnail-border-width solid $thumbnail-border-colour;
+  background: $thumbnail-background;
+  box-shadow: $thumbnail-shadow-width $thumbnail-shadow-colour;
+  fill: $thumbnail-icon-border-colour;
+  stroke: $thumbnail-icon-border-colour;
+}
+
+.gem-c-attachment__details {
+  padding-left: $thumbnail-width + $thumbnail-border-width * 2 + govuk-spacing(5);
+
+  .gem-c-details {
+    word-break: break-word;
+    word-wrap: break-word;
+  }
+}
+
+.gem-c-attachment__title {
+  @include govuk-font($size: 27);
+  margin: 0 0 govuk-spacing(3);
+}
+
+.gem-c-attachment__link {
+  line-height: 1.29;
+}
+
+.gem-c-attachment__metadata {
+  @include govuk-font($size: 14);
+  margin: 0 0 govuk-spacing(3);
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+}
+
+.gem-c-attachment__metadata--compact {
+  margin-bottom: 0;
+}
+
+.gem-c-attachment__abbr {
+  text-decoration: none;
+  cursor: help;
+}

--- a/app/assets/stylesheets/govspeak/helpers/_markdown-typography.scss
+++ b/app/assets/stylesheets/govspeak/helpers/_markdown-typography.scss
@@ -1,0 +1,147 @@
+@mixin markdown-typography {
+  @include govuk-text-colour;
+
+  @include govuk-font($size: 16);
+
+  $gutter-two-thirds: $govuk-gutter - ($govuk-gutter / 3);
+
+  ol,
+  ul,
+  p {
+    @include govuk-font($size: 19);
+    margin-top: $govuk-gutter-half;
+    margin-bottom: $govuk-gutter-half;
+
+    @include govuk-media-query($from: tablet) {
+      margin-top: $gutter-two-thirds;
+      margin-bottom: $gutter-two-thirds;
+    }
+  }
+
+  // Headings
+
+  // Markdown is expected to be styled within a document with a H1 title
+  // thus H1's are not expected and are discouraged by bare styling
+
+  /*
+  h1 {
+    @include govuk-font($size: 19);
+    margin: 0;
+    padding: 0;
+  }
+   */
+
+  h2 {
+    @include govuk-font($size: 27, $weight: bold);
+    margin-top: $govuk-gutter;
+    margin-bottom: 0;
+
+    @include govuk-media-query($from: desktop) {
+      margin-top: $govuk-gutter * 1.5;
+      margin-bottom: 0;
+    }
+  }
+
+  h3 {
+    @include govuk-font($size: 19, $weight: bold);
+    margin-top: $govuk-gutter + 5px;
+    margin-bottom: 0;
+  }
+
+  // H4, H5 and H6 are discouraged and thus styled the same
+
+  h4,
+  h5,
+  h6 {
+    @include govuk-font($size: 19, $weight: bold);
+    margin-top: $govuk-gutter + 5px;
+    margin-bottom: 0;
+
+    + p {
+      margin-top: 5px;
+    }
+  }
+
+  h5,
+  h6 {
+    margin: 0;
+  }
+
+  h2:first-child,
+  h3:first-child,
+  h4:first-child,
+  p:first-child {
+    margin-top: 0;
+  }
+
+  // Links
+
+  a {
+    @include govuk-link-style-default;
+
+    &:focus {
+      @include govuk-focused-text;
+    }
+  }
+
+  // Lists
+
+  ol,
+  ul {
+    list-style: decimal;
+    list-style-position: outside;
+    margin-left: $gutter-two-thirds;
+    padding: 0;
+
+    ul,
+    ol {
+      margin-top: 0;
+      margin-bottom: 0;
+      padding: 0;
+    }
+  }
+
+  ul {
+    list-style: disc;
+    list-style-position: outside;
+  }
+
+  li {
+    margin: 0 0 5px;
+    padding: 0;
+
+    p {
+      margin: 0;
+      padding: 0;
+    }
+
+    p + p,
+    p + ul,
+    p + ol,
+    ul + p,
+    ul + ol,
+    ol + p,
+    ol + ul {
+      margin-top: 5px;
+    }
+  }
+
+  // Text styles
+
+  sup {
+    font-size: .8em;
+    line-height: .7em;
+    vertical-align: super;
+  }
+
+  abbr {
+    cursor: help;
+    text-decoration: none;
+  }
+
+  // Horizontal Rule
+  hr {
+    margin-top: $govuk-gutter - 1px;
+    margin-bottom: $govuk-gutter;
+  }
+}

--- a/app/assets/stylesheets/govspeak/overrides/_accordion.scss
+++ b/app/assets/stylesheets/govspeak/overrides/_accordion.scss
@@ -1,0 +1,7 @@
+.gem-c-govspeak {
+  div.govuk-accordion__section-content {
+    a {
+      display: block;
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/overrides/_call-to-action.scss
+++ b/app/assets/stylesheets/govspeak/overrides/_call-to-action.scss
@@ -1,0 +1,25 @@
+// Govspeak call to action
+// https://components.publishing.service.gov.uk/component-guide/govspeak/call_to_action
+//
+// Support:
+//
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+.gem-c-govspeak {
+  .call-to-action {
+    margin: 2em 0;
+    background-color: govuk-colour("light-grey", $legacy: "grey-3");
+    padding: 2em;
+
+    &:first-child {
+      margin-top: 0;
+    }
+
+    p:last-child,
+    ul:last-child,
+    ol:last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/overrides/_contents-list.scss
+++ b/app/assets/stylesheets/govspeak/overrides/_contents-list.scss
@@ -1,0 +1,105 @@
+.gem-c-govspeak {
+
+  .contents-list__list-item--numbered {
+    .contents-list__link {
+      display: table;
+    }
+  }
+
+  .contents-list__number,
+  .contents-list__numbered-text {
+    display: table-cell;
+  }
+
+  .contents-list__number {
+    min-width: 1.5em;
+  }
+
+  .contents-list__numbered-text {
+    $contents-text-padding: .3em;
+    padding-left: $contents-text-padding;
+
+    .direction-rtl & {
+      padding-left: 0;
+      padding-right: $contents-text-padding;
+    }
+  }
+
+  .contents-list {
+    // Always render the contents list above a
+    // back to contents link
+    position: relative;
+    margin: 0 0 0 0;
+    z-index: 1;
+    background: govuk-colour("white");
+    box-shadow: 0 20px 15px -10px govuk-colour("white");
+  }
+
+  .contents-list__title {
+    @include govuk-text-colour;
+    @include govuk-font($size: 16, $weight: regular, $line-height: 1.5);
+    margin: 0;
+  }
+
+  .contents-list__list,
+  .contents-list__nested-list {
+    ul,
+    ol {
+      margin: 0
+    };
+    @include govuk-text-colour;
+    @include govuk-font($size: 16);
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  .contents-list__link {
+    .contents-list__list-item--parent > & {
+      font-weight: bold;
+    }
+
+  }
+
+  .contents-list__list-item {
+    padding-top: govuk-spacing(2);
+    line-height: 1.3;
+    list-style-type: none;
+
+    @include govuk-media-query($from: tablet) {
+      padding-top: govuk-spacing(6) / 4;
+    }
+  }
+
+  .contents-list__list-item--dashed {
+    $contents-spacing: govuk-spacing(5);
+    position: relative;
+    padding-left: $contents-spacing;
+    padding-right: $contents-spacing;
+
+    &:before {
+      content: "—";
+      position: absolute;
+      left: 0;
+      width: govuk-spacing(4);
+      overflow: hidden;
+
+      .direction-rtl & {
+        left: auto;
+        right: 0;
+      }
+    }
+
+    // Focus styles on IE8 and older include the
+    // left margin, creating an odd white box with
+    // orange border around the em dash.
+    // Use inline-block and vertical alignment to
+    // fix focus styles
+    //
+    // https://github.com/alphagov/government-frontend/pull/420#issuecomment-320632386
+    .lte-ie8 & .contents-list__link {
+      display: inline-block;
+      vertical-align: top;
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/overrides/_highlights.scss
+++ b/app/assets/stylesheets/govspeak/overrides/_highlights.scss
@@ -1,0 +1,8 @@
+.gem-c-govspeak {
+  .information {
+    border-style: solid;
+    border-radius: 9px;
+    padding: 40px;
+    margin: 50px;
+  }
+}

--- a/app/assets/stylesheets/govspeak/overrides/_quote.scss
+++ b/app/assets/stylesheets/govspeak/overrides/_quote.scss
@@ -1,0 +1,16 @@
+.gem-c-govspeak blockquote {
+  p:before {
+    margin-left: 0;
+  }
+  p:after {
+    content: "";
+  }
+  p:last-child:after {
+    content: "";
+  }
+  p {
+    border-left: 10px solid #b1b4b6;
+    padding: 15px;
+    clear: both;
+  }
+}

--- a/app/assets/stylesheets/govspeak/overrides/_tables.scss
+++ b/app/assets/stylesheets/govspeak/overrides/_tables.scss
@@ -1,0 +1,40 @@
+// Govspeak tables
+// https://components.publishing.service.gov.uk/component-guide/govspeak/tables
+//
+// Support:
+// - alphagov/whitehall: ✔︎
+// - alphagov/govspeak: ✔︎
+
+.gem-c-govspeak {
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    display: block;
+    margin: govuk-spacing(6) 0;
+    overflow-x: auto;
+    width: 100%;
+    @include govuk-font($size: 14);
+
+    caption {
+      text-align: left;
+      margin-bottom: .5em;
+    }
+
+    th,
+    td {
+      vertical-align: top;
+      padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
+      border-bottom: solid 1px govuk-colour("mid-grey", $legacy: "grey-2");
+    }
+
+    th {
+      @include govuk-font($size: 14, $weight: bold);
+      text-align: left;
+      color: $govuk-text-colour;
+    }
+
+    td small {
+      font-size: 1em;
+    }
+  }
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,13 +3,4 @@ import "@hotwired/turbo-rails";
 
 import { initAll } from "govuk-frontend";
 
-/*
-WIP: asset pipeline needs the following from the gem
-https://github.com/alphagov/govuk_publishing_components/blob/main/docs/install-and-use.md
-import "govuk_publishing_components/dependencies";
-import "govuk_publishing_components/lib";
-import "govuk_publishing_components/components/button";
-*/
-
-
 initAll();

--- a/app/views/content_pages/module_intro.html.slim
+++ b/app/views/content_pages/module_intro.html.slim
@@ -3,6 +3,7 @@
 - content_for :content_page do
   h1= @model.heading
   = image_tag(@model.image) if @model.image.present?
-  = translate_markdown(@model.body)
+  .gem-c-govspeak
+    = translate_markdown(@model.body)
 
 = render 'shared/content_wrap'

--- a/app/views/content_pages/module_intro.html.slim
+++ b/app/views/content_pages/module_intro.html.slim
@@ -2,7 +2,9 @@
 
 - content_for :content_page do
   h1= @model.heading
+
   = image_tag(@model.image) if @model.image.present?
+
   .gem-c-govspeak
     = translate_markdown(@model.body)
 

--- a/app/views/formative_assessments/show.html.slim
+++ b/app/views/formative_assessments/show.html.slim
@@ -1,7 +1,7 @@
-h1= @questionnaire.heading
+h1
+  = @questionnaire.heading
 
--# https://components.publishing.service.gov.uk/component-guide/govspeak
-= render 'govuk_publishing_components/components/govspeak', {} do
+.gem-c-govspeak
   = translate_markdown(@questionnaire.body)
 
 = form_with model: @questionnaire, url: training_module_formative_assessment_path(@training_module, @questionnaire), method: :patch do |f|

--- a/app/views/questionnaires/show.html.slim
+++ b/app/views/questionnaires/show.html.slim
@@ -1,9 +1,9 @@
 = render 'debug'
 
-h1= @questionnaire.heading
+h1
+  = @questionnaire.heading
 
--# https://components.publishing.service.gov.uk/component-guide/govspeak
-= render 'govuk_publishing_components/components/govspeak' do
+.gem-c-govspeak
   = translate_markdown(@questionnaire.body)
 
 = form_with model: @questionnaire, url: training_module_questionnaire_path(@training_module, @questionnaire), method: :patch do |form|

--- a/config/locales/modules/one.yml
+++ b/config/locales/modules/one.yml
@@ -6,8 +6,88 @@ en:
   modules:
     one:
       1:      # http://localhost:3000/modules/one/content_pages/1
-        heading: Module 1 - Foo
-        body: This is important and here is some text
+        heading: First Example Module (Govspeak)
+        body: |
+          %Warning: people like stuff!%
+
+          s1. numbers
+          s2. to the start
+          s3. of your list
+
+          &lsquo; write content here &rsquo;
+
+          {button start}[Start Now](https://gov.uk/random){/button}
+
+          <h1 class="govuk-heading-l">govuk-heading-l</h1>
+
+          ^This is an information callout^
+
+          $E
+          **Example**: Open the pod bay doors
+          $E
+
+          {stat-headline}
+          *13.8bn* years since the big bang
+          {/stat-headline}
+
+          $C
+          **Student Finance England**
+          **Telephone:** 0845 300 50 90
+          **Minicom:** 0845 604 44 34
+          $C
+
+          $A
+          Hercules House
+          Hercules Road
+          London SE1 7DU
+          $A
+
+          $P
+          This is a place
+          $P
+
+          $CTA
+          This is a call to action
+          $CTA
+
+          $D
+          [An example form download link](http://example.com/ "Example form")
+
+          Something about this form download
+          $D
+
+          $!
+          This is a summary
+          $!
+
+
+          |               |# Column header one |# Column header two |
+          |---------------|--------------------|--------------------|
+          |# Row header 1 | Content #1         | Content #2         |
+          |# Row header 1 | Content #3         | Content #4         |
+
+          :england:content goes here:england:
+          :scotland:content goes here:scotland:
+          :london:content goes here:london:
+          :wales:content goes here:wales:
+          :northern-ireland:content goes here:northern-ireland:
+          :england-wales:content goes here:england-wales:
+
+          %You will be fined or put in prison if you don't do this thing.%
+
+          ### Contact
+          $C
+          Financial Conduct Authority
+          <consumer.queries@fca.org.uk>
+
+          Telephone: 0800 111 6768
+
+          Monday to Friday, 8am to 6pm
+          Saturday, 9am to 1pm
+
+          [Find out about call charges](/call-charges)
+          $C
+
       1-1:    # http://localhost:3000/modules/one/content_pages/1-1
         heading: Foo Part One
         body: In this submodule we'll discuss some stuff


### PR DESCRIPTION
This is a variation on another open PR where govspeak styling is committed to the repo.

This PR achieves it by mimicking Reform, including some customisation.