### PR TITLE
Er 214 account locked for 2 hours

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,8 @@ FEEDBACK_URL=
 
 TIMEOUT_MINUTES=
 
-# Time interval to unlock the account if :time is enabled as unlock_strategy.
+# Time interval to unlock the account if :time is enabled as unlock_strategy
+# Can be entered as ActiveSupport::Duration, such as '1.minute'
 UNLOCK_IN=
 
 # user acceptance tests

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ FEEDBACK_URL=
 
 TIMEOUT_MINUTES=
 
+# Time interval to unlock the account if :time is enabled as unlock_strategy.
+UNLOCK_IN=
+
 # user acceptance tests
 BASE_URL=
 BROWSER=

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -240,7 +240,12 @@ Devise.setup do |config|
   config.maximum_attempts = 5
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  config.unlock_in = 2.hours
+  time = ENV.fetch('UNLOCK_IN',2.hours)
+  if time.class == String
+    parts = time.split('.')
+    time = parts.first.to_i.send(parts.last)
+  end
+  config.unlock_in = time
 
   # Warn on the last attempt before the account is locked.
   config.last_attempt_warning = true


### PR DESCRIPTION
Add code to accept environment variable ```UNLOCK_IN```. Allows setting the duration that account is locked for, for testing purposes. ```UNLOCK_IN``` can be a Rails ```ActiveSupport::Duration``` such as '1.hour' or '1.minute'