### PR TITLE
Er 181 not received confirmation email

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -2,7 +2,6 @@ class ConfirmationsController < Devise::ConfirmationsController
   protected
   
   def after_resending_confirmation_instructions_path_for(resource_name)
-    # TODO: add check email
-    # check_email_confirmation_user_path
+    check_email_confirmation_user_path
   end
 end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,7 +1,7 @@
 class ConfirmationsController < Devise::ConfirmationsController
-  protected
-  
-  def after_resending_confirmation_instructions_path_for(resource_name)
+protected
+
+  def after_resending_confirmation_instructions_path_for(_resource_name)
     check_email_confirmation_user_path
   end
 end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,8 @@
+class ConfirmationsController < Devise::ConfirmationsController
+  protected
+  
+  def after_resending_confirmation_instructions_path_for(resource_name)
+    # TODO: add check email
+    # check_email_confirmation_user_path
+  end
+end

--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -1,4 +1,4 @@
-- if url_for(:back).include?('my-account/check_email_confirmation')
+- if url_for(:back).include?(check_email_confirmation_user_path)
   a.govuk-back-link href=url_for(:back) Back
 - content_for :devise_form do
   = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
@@ -11,5 +11,5 @@
 
 = render "devise/shared/form_wrap"
 
-- if url_for(:back).include?('my-account/check_email_confirmation')
+- if url_for(:back).include?(check_email_confirmation_user_path)
   a.govuk-link href=url_for(:back) Go back to check your email

--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -1,3 +1,5 @@
+- if url_for(:back).include?('my-account/check_email_confirmation')
+  a.govuk-back-link href=url_for(:back) Back
 - content_for :devise_form do
   = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
     = f.govuk_error_summary
@@ -8,3 +10,6 @@
     = f.govuk_submit "Send email"
 
 = render "devise/shared/form_wrap"
+
+- if url_for(:back).include?('my-account/check_email_confirmation')
+  a.govuk-link href=url_for(:back) Go back to check your email

--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -1,4 +1,3 @@
-a.govuk-back-link href=url_for(:back) Back
 - content_for :devise_form do
   = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
     = f.govuk_error_summary
@@ -8,4 +7,4 @@ a.govuk-back-link href=url_for(:back) Back
       = f.govuk_email_field :email, autofocus: true, autocomplete: "email", value: resource.email_to_confirm, label: { text: t('helpers.label.user.email') }
     = f.govuk_submit "Send email"
 
-= render 'devise/shared/form_wrap'
+= render "devise/shared/form_wrap"

--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -4,7 +4,7 @@
     = f.govuk_fieldset legend: { text: 'Resend your confirmation'} do
       p.govuk-body
         | If you haven't received an email from us containing a link to validate your email, please check your spam folder.
-      = f.govuk_email_field :email, autofocus: true, autocomplete: "email", value: resource.email_to_confirm, label: { text: t(:email) }
+      = f.govuk_email_field :email, autofocus: true, autocomplete: "email", value: resource.email_to_confirm, label: { text: t('helpers.label.user.email') }
     = f.govuk_submit "Send email"
 
 = render 'devise/shared/form_wrap'

--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -1,3 +1,4 @@
+a.govuk-back-link href=url_for(:back) Back
 - content_for :devise_form do
   = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
     = f.govuk_error_summary

--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -1,8 +1,10 @@
 - content_for :devise_form do
   = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
     = f.govuk_error_summary
-    = f.govuk_fieldset legend: { text: 'Resend confirmation instructions'} do
-      = f.govuk_email_field :email, autofocus: true, autocomplete: 'email', value: resource.email_to_confirm, label: { text: t(:email) }
-    = f.govuk_submit 'Resend confirmation instructions'
+    = f.govuk_fieldset legend: { text: 'Resend your confirmation'} do
+      p.govuk-body
+        | If you haven't received an email from us containing a link to validate your email, please check your spam folder.
+      = f.govuk_email_field :email, autofocus: true, autocomplete: "email", value: resource.email_to_confirm, label: { text: t(:email) }
+    = f.govuk_submit "Send email"
 
 = render 'devise/shared/form_wrap'

--- a/app/views/user/check_email_confirmation.html.slim
+++ b/app/views/user/check_email_confirmation.html.slim
@@ -1,12 +1,14 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds-from-desktop
+    / on second visit to users/confirmation/new, email is not available so display generic page
+    - user = @user.nil? ? :user : @user
     h1.govuk-heading-l #{t('check_email_confirmation.heading')}
 
     p.govuk-body
       | #{t('check_email_confirmation.body')}
 
     p class="govuk-body govuk-!-font-weight-bold"
-      = @user.email
+        = user.email unless @user.nil?
 
     p.govuk-body
       | #{t('check_email_confirmation.body_two')}
@@ -16,11 +18,11 @@
     = govuk_details(summary_text: t('check_email_confirmation.summary_text')) do
       p.govuk-heading-s= t('check_email_confirmation.not_recieved.title')
       p.govuk-body= t('check_email_confirmation.not_recieved.text')
-      p= govuk_link_to t('check_email_confirmation.not_recieved.link_text'), new_confirmation_path(@user)
+      p= govuk_link_to t('check_email_confirmation.not_recieved.link_text'), new_confirmation_path(user)
 
       p.govuk-heading-s= t('check_email_confirmation.no_access_to_email.title')
       p.govuk-body= t('check_email_confirmation.no_access_to_email.text')
-      p.govuk-body Please #{govuk_link_to t('check_email_confirmation.no_access_to_email.link_text'), new_registration_path(@user)}.
+      p.govuk-body Please #{govuk_link_to t('check_email_confirmation.no_access_to_email.link_text'), new_registration_path(user)}.
 
       p.govuk-heading-s= t('check_email_confirmation.diff_problem.title') 
       p.govuk-body #{t('check_email_confirmation.diff_problem.text')}

--- a/app/views/user/check_email_confirmation.html.slim
+++ b/app/views/user/check_email_confirmation.html.slim
@@ -2,16 +2,18 @@
   .govuk-grid-column-two-thirds-from-desktop
     / on second visit to users/confirmation/new, email is not available so display generic page
     - user = @user.nil? ? :user : @user
+
     h1.govuk-heading-l #{t('check_email_confirmation.heading')}
 
     p.govuk-body
-      | #{t('check_email_confirmation.body')}
+      = t('check_email_confirmation.body.one')
+      = " " + t('check_email_confirmation.body.two') unless @user.nil?
 
     p class="govuk-body govuk-!-font-weight-bold"
         = user.email unless @user.nil?
 
     p.govuk-body
-      | #{t('check_email_confirmation.body_two')}
+      | #{t('check_email_confirmation.body.three')}
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds-from-desktop

--- a/app/views/user/check_email_confirmation.html.slim
+++ b/app/views/user/check_email_confirmation.html.slim
@@ -6,14 +6,14 @@
     h1.govuk-heading-l #{t('check_email_confirmation.heading')}
 
     p.govuk-body
-      = t('check_email_confirmation.body.one')
-      = " " + t('check_email_confirmation.body.two') unless @user.nil?
+      = t('check_email_confirmation.body.0')
+      = " " + t('check_email_confirmation.body.1') unless @user.nil?
 
     p class="govuk-body govuk-!-font-weight-bold"
         = user.email unless @user.nil?
 
     p.govuk-body
-      | #{t('check_email_confirmation.body.three')}
+      | #{t('check_email_confirmation.body.2')}
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds-from-desktop

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,9 +146,9 @@ en:
   check_email_confirmation:
     heading: Check your email
     body: 
-      one: We have sent you an email with instructions for how to verify your email address.
-      two: "We sent the email to:"
-      three: To continue setting up your training account you must click the link in the email. If you have not recieved the email after a few minutes, please check your spam folder.
+      0: We have sent you an email with instructions for how to verify your email address.
+      1: "We sent the email to:"
+      2: To continue setting up your training account you must click the link in the email. If you have not recieved the email after a few minutes, please check your spam folder.
     summary_text: Problems with the activation email?
     not_recieved:
       title: I haven’t received the email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,12 +145,10 @@ en:
 
   check_email_confirmation:
     heading: Check your email
-    body: |
-      We have sent you an email with instructions for how to verify your email address.
-      We sent the email to:
-    body_two: |
-      To continue setting up your training account you must click the link in the email.
-      If you have not recieved the email after a few minutes, please check your spam folder.
+    body: 
+      one: We have sent you an email with instructions for how to verify your email address.
+      two: "We sent the email to:"
+      three: To continue setting up your training account you must click the link in the email. If you have not recieved the email after a few minutes, please check your spam folder.
     summary_text: Problems with the activation email?
     not_recieved:
       title: I haven’t received the email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,9 +146,13 @@ en:
   check_email_confirmation:
     heading: Check your email
     body: 
-      0: We have sent you an email with instructions for how to verify your email address.
-      1: "We sent the email to:"
-      2: To continue setting up your training account you must click the link in the email. If you have not recieved the email after a few minutes, please check your spam folder.
+      0: | 
+        We have sent you an email with instructions for how to verify your email address.
+      1: |
+        We sent the email to:
+      2: |
+        To continue setting up your training account you must click the link in the email.
+        If you have not recieved the email after a few minutes, please check your spam folder.
     summary_text: Problems with the activation email?
     not_recieved:
       title: I haven’t received the email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
 
   resources :settings, only: :show
 
-  devise_for :users, controllers: { sessions: 'users/sessions', passwords: 'passwords', registrations: 'registrations' }, path_names: { sign_in: 'sign-in', sign_out: 'sign-out', sign_up: 'sign-up' }
+  devise_for :users, controllers: { sessions: 'users/sessions', confirmations: 'confirmations', passwords: 'passwords', registrations: 'registrations' }, path_names: { sign_in: 'sign-in', sign_out: 'sign-out', sign_up: 'sign-up' }
   resources :extra_registrations, only: %i[index edit update], path: 'extra-registrations'
 
   resource :user, controller: :user, path: 'my-account', only: %i[show] do

--- a/spec/system/registration_journey_spec.rb
+++ b/spec/system/registration_journey_spec.rb
@@ -11,36 +11,36 @@ RSpec.describe 'Following registration journey' do
     context 'and can click on "I haven\'t receieved the email" link' do
       it 'taken to "resend your confirmation" page' do
         click_on 'Send me another email', visible: :hidden
-        
-        expect(page.current_path).to eq(new_user_confirmation_path)
+
+        expect(page).to have_current_path(new_user_confirmation_path, ignore_query: true)
         expect(page).to have_text('Resend your confirmation')
       end
     end
-      
+
     context 'and can click on the "I don\'t have access to the email" link' do
       it 'I am taken to the ‘create your account’ page to re-register' do
         click_on 'create a new account', visible: :hidden
-        
-        expect(page.current_path).to eq(new_user_registration_path)
+
+        expect(page).to have_current_path(new_user_registration_path, ignore_query: true)
         expect(page).to have_text('Create an early years training account')
       end
     end
-      
+
     context 'and can click on the ‘other problems’ link' do
       it 'taken to the ‘MS form to contact us’' do
         expect(page).to have_link 'contact us', href: '#', visible: :hidden
       end
     end
-    
+
     context 'and navigate to "resend your confirmation"' do
       it 'can click on a back button to be taken to the "check your email" page' do
         click_on 'Send me another email', visible: :hidden
         click_on 'Go back to check your email'
-        expect(page).to have_text("Check your email")
+        expect(page).to have_text('Check your email')
       end
     end
   end
-  
+
   context 'when on the ‘resend your confirmation’ page' do
     before do
       visit new_user_confirmation_path
@@ -48,12 +48,11 @@ RSpec.describe 'Following registration journey' do
 
     context 'and can enter email address and click send' do
       it 'taken to the confirmation email sent page' do
-        fill_in "Email address", with: user.email
+        fill_in 'Email address', with: user.email
         click_on 'Send email'
 
-        expect(page).to have_text("Check your email")
+        expect(page).to have_text('Check your email')
       end
     end
-    
   end
 end

--- a/spec/system/registration_journey_spec.rb
+++ b/spec/system/registration_journey_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe 'Following registration journey' do
 
   context 'when on the check your email page' do
     before do
-      visit "my-account/check_email_confirmation?email=#{user.email}"
+      visit check_email_confirmation_user_path + "?email=#{user.email}"
     end
 
     context 'and can click on "I haven\'t receieved the email" link' do
       it 'taken to "resend your confirmation" page' do
         click_on 'Send me another email', visible: :hidden
         
-        expect(page.current_path).to eq('/users/confirmation/new')
+        expect(page.current_path).to eq(new_user_confirmation_path)
         expect(page).to have_text('Resend your confirmation')
       end
     end
@@ -21,7 +21,7 @@ RSpec.describe 'Following registration journey' do
       it 'I am taken to the ‘create your account’ page to re-register' do
         click_on 'create a new account', visible: :hidden
         
-        expect(page.current_path).to eq('/users/sign_up')
+        expect(page.current_path).to eq(new_user_registration_path)
         expect(page).to have_text('Create an early years training account')
       end
     end
@@ -43,7 +43,7 @@ RSpec.describe 'Following registration journey' do
   
   context 'when on the ‘resend your confirmation’ page' do
     before do
-      visit "/users/confirmation/new"
+      visit new_user_confirmation_path
     end
 
     context 'and can enter email address and click send' do

--- a/spec/system/registration_journey_spec.rb
+++ b/spec/system/registration_journey_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'Following registration journey' do
+  let(:user) { create :user }
+
+  context 'when on the check your email page' do
+    before do
+      visit "my-account/check_email_confirmation?email=#{user.email}"
+    end
+
+    context 'and can click on "I haven\'t receieved the email" link' do
+      it 'taken to "resend your confirmation" page' do
+        click_on 'Send me another email', visible: :hidden
+        
+        expect(page.current_path).to eq('/users/confirmation/new')
+        expect(page).to have_text('Resend your confirmation')
+      end
+    end
+      
+    context 'and can click on the "I don\'t have access to the email" link' do
+      it 'I am taken to the ‘create your account’ page to re-register' do
+        click_on 'create a new account', visible: :hidden
+        
+        expect(page.current_path).to eq('/users/sign_up')
+        expect(page).to have_text('Create an early years training account')
+      end
+    end
+      
+    context 'and can click on the ‘other problems’ link' do
+      it 'taken to the ‘MS form to contact us’' do
+        expect(page).to have_link 'contact us', href: '#', visible: :hidden
+      end
+    end
+    
+    context 'and navigate to "resend your confirmation"' do
+      it 'can click on a back button to be taken to the "check your email" page' do
+        click_on 'Send me another email', visible: :hidden
+        click_on 'Go back to check your email'
+        expect(page).to have_text("Check your email")
+      end
+    end
+  end
+  
+  context 'when on the ‘resend your confirmation’ page' do
+    before do
+      visit "/users/confirmation/new"
+    end
+
+    context 'and can enter email address and click send' do
+      it 'taken to the confirmation email sent page' do
+        fill_in "Email address", with: user.email
+        click_on 'Send email'
+
+        expect(page).to have_text("Check your email")
+      end
+    end
+    
+  end
+end


### PR DESCRIPTION
Ticket: [ER-181](https://dfedigital.atlassian.net/browse/ER-181)

- Update 'Check your email' page to work if it cannot access the user's email address
    - Change content to reflect this
    - This is the case when a user does the following: 
    Registration page > Check your email page > Resend your confirmation page > Check your email page
- Add back buttons x 2 to 'Resend your confirmation' page
- Add specs to test acceptance criteria in the ticket