### PR TITLE
Introduce the 'activation_instructions' email

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,5 +1,26 @@
 class ConfirmationsController < Devise::ConfirmationsController
+
+  def show
+    self.resource = resource_class.confirm_by_token(params[:confirmation_token])
+    yield resource if block_given?
+
+    if resource.errors.empty?
+      set_flash_message!(:notice, (resource.registration_complete ? :confirmed : :activated))
+      respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource_name, resource) }
+    else
+      respond_with_navigational(resource.errors, status: :unprocessable_entity){ render :new }
+    end
+  end
+
 protected
+
+  def after_confirmation_path_for(resource_name, resource)
+    if signed_in?(resource_name)
+      user_path
+    else
+      new_session_path(resource_name)
+    end
+  end
 
   def after_resending_confirmation_instructions_path_for(_resource_name)
     check_email_confirmation_user_path

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,20 +1,19 @@
 class ConfirmationsController < Devise::ConfirmationsController
-
   def show
     self.resource = resource_class.confirm_by_token(params[:confirmation_token])
     yield resource if block_given?
 
     if resource.errors.empty?
       set_flash_message!(:notice, (resource.registration_complete ? :confirmed : :activated))
-      respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource_name, resource) }
+      respond_with_navigational(resource) { redirect_to after_confirmation_path_for(resource_name, resource) }
     else
-      respond_with_navigational(resource.errors, status: :unprocessable_entity){ render :new }
+      respond_with_navigational(resource.errors, status: :unprocessable_entity) { render :new }
     end
   end
 
 protected
 
-  def after_confirmation_path_for(resource_name, resource)
+  def after_confirmation_path_for(resource_name, _resource)
     if signed_in?(resource_name)
       user_path
     else

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -32,7 +32,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
     set_personalisation(
       confirmation_url: confirmation_url(record, confirmation_token: token),
     )
-    mail(to: record.email)
+    mail(to: record.unconfirmed_email? ? record.unconfirmed_email : record.email)
   end
 
   def confirmation_instructions(record, token, _opts = {})
@@ -41,7 +41,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
     set_personalisation(
       confirmation_url: confirmation_url(record, confirmation_token: token),
     )
-    mail(to: record.email)
+    mail(to: record.unconfirmed_email? ? record.unconfirmed_email : record.email)
   end
 
   def reset_password_instructions(record, token, _opts = {})

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -84,7 +84,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
       name: record.name,
       is_unconfirmed_email: record.unconfirmed_email? ? 'Yes' : 'No',
       is_not_unconfirmed_email: record.unconfirmed_email? ? 'No' : 'Yes',
-      email: record.email,
+      email: record.unconfirmed_email? ? record.unconfirmed_email : record.email,
     )
     mail(to: record.email)
   end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,6 +1,7 @@
 class NotifyMailer < GovukNotifyRails::Mailer
   BLANK_TEMPLATE_ID = '36555d23-b0e0-4c10-9b85-9c79c98eb1fe'.freeze
-  CONFIRMATION_TEMPLATE_ID = 'a44bc231-d779-41d8-a5e0-180497dfa711'.freeze
+  ACTIVATION_TEMPLATE_ID = 'd6ab2e3b-923e-429e-abd2-cfe7be0e9193'.freeze
+  CONFIRMATION_TEMPLATE_ID = 'a2412831-e253-4df4-a8f1-19332eed4cef'.freeze
   RESET_PASSWORD_TEMPLATE_ID = 'ad77aab8-d903-4f77-b074-a16c2658ca79'.freeze
   UNLOCK_TEMPLATE_ID = 'e18e8419-cfcc-4fcb-abdb-84f932f3cf55'.freeze
   PASSWORD_CHANGED_TEMPLATE_ID = 'f77e1eba-3fa8-45ae-9cec-a4cc54633395'.freeze
@@ -25,12 +26,19 @@ class NotifyMailer < GovukNotifyRails::Mailer
     mail to: 'brett.mchargue@education.gov.uk'
   end
 
+  def activation_instructions(record, token, _opts = {})
+    set_template(ACTIVATION_TEMPLATE_ID)
+
+    set_personalisation(
+      confirmation_url: confirmation_url(record, confirmation_token: token),
+    )
+    mail(to: record.email)
+  end
+
   def confirmation_instructions(record, token, _opts = {})
     set_template(CONFIRMATION_TEMPLATE_ID)
 
     set_personalisation(
-      email_subject: 'Activate your GOV.UK child development training account',
-      name: record.name,
       confirmation_url: confirmation_url(record, confirmation_token: token),
     )
     mail(to: record.email)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,8 +42,8 @@ class User < ApplicationRecord
     unless @raw_confirmation_token
       generate_confirmation_token!
     end
-    
-    opts = pending_reconfirmation? ? { to: unconfirmed_email } : { }
+
+    opts = pending_reconfirmation? ? { to: unconfirmed_email } : {}
     if registration_complete
       send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,18 @@ class User < ApplicationRecord
     super
   end
 
+  # @see Devise::Confirmable
+  # send_confirmation_instructions
+  def send_on_create_confirmation_instructions
+    unless @raw_confirmation_token
+      generate_confirmation_token!
+    end
+    
+    opts = pending_reconfirmation? ? { to: unconfirmed_email } : { }
+    send_devise_notification(:activation_instructions, @raw_confirmation_token, opts)
+  end
+
+
   # @return [String]
   def name
     [first_name, last_name].compact.join(' ')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,15 +38,18 @@ class User < ApplicationRecord
 
   # @see Devise::Confirmable
   # send_confirmation_instructions
-  def send_on_create_confirmation_instructions
+  def send_confirmation_instructions
     unless @raw_confirmation_token
       generate_confirmation_token!
     end
     
     opts = pending_reconfirmation? ? { to: unconfirmed_email } : { }
-    send_devise_notification(:activation_instructions, @raw_confirmation_token, opts)
+    if registration_complete
+      send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
+    else
+      send_devise_notification(:activation_instructions, @raw_confirmation_token, opts)
+    end
   end
-
 
   # @return [String]
   def name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,11 +44,8 @@ class User < ApplicationRecord
     end
 
     opts = pending_reconfirmation? ? { to: unconfirmed_email } : {}
-    if registration_complete
-      send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
-    else
-      send_devise_notification(:activation_instructions, @raw_confirmation_token, opts)
-    end
+    mailer = registration_complete? ? :confirmation_instructions : :activation_instructions
+    send_devise_notification(mailer, @raw_confirmation_token, opts)
   end
 
   # @return [String]

--- a/app/views/user/check_email_confirmation.html.slim
+++ b/app/views/user/check_email_confirmation.html.slim
@@ -19,9 +19,9 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds-from-desktop
     = govuk_details(summary_text: t('check_email_confirmation.summary_text')) do
-      p.govuk-heading-s= t('check_email_confirmation.not_recieved.title')
-      p.govuk-body= t('check_email_confirmation.not_recieved.text')
-      p= govuk_link_to t('check_email_confirmation.not_recieved.link_text'), new_confirmation_path(user)
+      p.govuk-heading-s= t('check_email_confirmation.not_received.title')
+      p.govuk-body= t('check_email_confirmation.not_received.text')
+      p= govuk_link_to t('check_email_confirmation.not_received.link_text'), new_confirmation_path(user)
 
       p.govuk-heading-s= t('check_email_confirmation.no_access_to_email.title')
       p.govuk-body= t('check_email_confirmation.no_access_to_email.text')

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -28,8 +28,10 @@ en:
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
+      activation_instructions:
+        subject: "Activate your GOV.UK early years training account"
       confirmation_instructions:
-        subject: "Activate your GOV.UK child development training account"
+        subject: "Confirm your email"
       reset_password_instructions:
         subject: "Reset password instructions"
       unlock_instructions:

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -4,7 +4,7 @@ en:
   devise:
     confirmations:
       confirmed: "Your email address has been successfully confirmed."
-      confirmed: |
+      activated: |
         Thank you, your email address is now verified.
         <br/>
         <br/>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -191,9 +191,9 @@ en:
         We sent the email to:
       2: |
         To continue setting up your training account you must click the link in the email.
-        If you have not recieved the email after a few minutes, please check your spam folder.
+        If you have not received the email after a few minutes, please check your spam folder.
     summary_text: Problems with the activation email?
-    not_recieved:
+    not_received:
       title: I haven’t received the email
       text: |
         Please wait a few minutes for the email to arrive.
@@ -212,7 +212,7 @@ en:
     heading: Check your email
     body:
       - We have sent you an email with instructions for how to reset your password.
-      - If you have not receieved the email after a few minutes, please check your spam folder.
+      - If you have not received the email after a few minutes, please check your spam folder.
     summary_text: Problems with the email?
     not_received:
       title: I haven’t received the email

--- a/config/locales/modules/brain-development-and-how-children-learn.yml
+++ b/config/locales/modules/brain-development-and-how-children-learn.yml
@@ -680,7 +680,7 @@ en:
 
           Skinner believed that children learn as a result of what happens after a learning experience. For example, if a child has participated in an activity where they received praise, they are more likely to repeat that experience and further develop their understanding
 
-          Skinner also believed that if a child’s behaviour or actions resulted in an unpleasant outcome or recieved a negative consequence, they would be unlikely to repeat it.
+          Skinner also believed that if a child’s behaviour or actions resulted in an unpleasant outcome or received a negative consequence, they would be unlikely to repeat it.
 
           Skinner stated that behaviour was learnt from the environment with no influence from inherited factors. Skinner thought we could therefore predict or control behaviour.
 

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe NotifyMailer, type: :mailer do
         expect(response.subject).to eq 'Activation instructions'
       end
     end
+
     context 'when already signed up' do
       it 'send confirmation email to correct user' do
         user.registration_complete = true

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -3,9 +3,17 @@ require 'rails_helper'
 RSpec.describe NotifyMailer, type: :mailer do
   let(:user) { create(:user) }
 
-  describe 'user sign up' do
+  describe 'email confirmation / account activation' do
     context 'when signing up' do
+      it 'send activation email to correct user' do
+        response = user.send_confirmation_instructions
+        expect(response.recipients).to contain_exactly(user.email)
+        expect(response.subject).to eq 'Activation instructions'
+      end
+    end
+    context 'when already signed up' do
       it 'send confirmation email to correct user' do
+        user.registration_complete = true
         response = user.send_confirmation_instructions
         expect(response.recipients).to contain_exactly(user.email)
         expect(response.subject).to eq 'Confirmation instructions'

--- a/spec/system/registration_journey_spec.rb
+++ b/spec/system/registration_journey_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Following registration journey' do
       visit check_email_confirmation_user_path + "?email=#{user.email}"
     end
 
-    context 'and can click on "I haven\'t receieved the email" link' do
+    context 'and can click on "I haven\'t received the email" link' do
       it 'taken to "resend your confirmation" page' do
         click_on 'Send me another email', visible: :hidden
 


### PR DESCRIPTION
This PR for [ER-282](https://dfedigital.atlassian.net/browse/ER-282) and [ER-273](https://dfedigital.atlassian.net/browse/ER-273) introduces a new template for account activation.  Previously the 'confirmation_instructions` template was used both for user account creation and user account update.  Now the template 'activation_instructions' is used for the creation and 'email_confirmation_instructions' is used for the update.  Once this is merged we can remove the 'confirmation_instructions' template on Notify (https://notifications.service.gov.uk)
