### PR TITLE
create account journey content changes

### DIFF
--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -7,7 +7,7 @@
 
       = f.govuk_password_field :current_password
       = f.govuk_password_field :password, label: { text: 'Create a new password' }
-      = f.govuk_password_field :password_confirmation, label: { text: 'Re-type your new password' }
+      = f.govuk_password_field :password_confirmation, label: { text: 'Confirm password' }
     = f.govuk_submit 'Save'
 
 = render 'devise/shared/form_wrap'

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -1,4 +1,4 @@
-= link_to 'Back', root_path, class: 'govuk-back-link'
+= govuk_link_to 'Back', root_path, class: 'govuk-back-link'
 - content_for :devise_form do
   = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
     = f.govuk_error_summary
@@ -9,7 +9,7 @@
       = f.govuk_password_field :password, label: { text: 'Create password' }, hint: { text: t('password.hardness', length: @minimum_password_length) }
       = f.govuk_password_field :password_confirmation
       = govuk_inset_text do 
-        p By continuing, you accept the #{link_to 'terms and conditions', static_path('terms-and-conditions'), class: 'govuk-link'} and #{link_to 'privacy policy', static_path('privacy-policy'), class: 'govuk-link'}.
+        p By continuing, you accept the #{govuk_link_to 'terms and conditions', static_path('terms-and-conditions')} and #{govuk_link_to 'privacy policy', static_path('privacy-policy')}.
     = f.govuk_submit 'Continue'
 
 = render 'devise/shared/form_wrap'

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -9,8 +9,7 @@
       = f.govuk_password_field :password, label: { text: 'Create password' }, hint: { text: t('password.hardness', length: @minimum_password_length) }
       = f.govuk_password_field :password_confirmation
       = govuk_inset_text do 
-        p 
-          | By continuing, you accept the #{link_to "terms and conditions", static_path('terms-and-conditions')} and #{link_to "privacy policy", static_path('privacy-policy')}.
+        p By continuing, you accept the #{link_to 'terms and conditions', static_path('terms-and-conditions'), class: 'govuk-link'} and #{link_to 'privacy policy', static_path('privacy-policy'), class: 'govuk-link'}.
     = f.govuk_submit 'Continue'
 
 = render 'devise/shared/form_wrap'

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -7,6 +7,9 @@
       = f.govuk_email_field :email, autofocus: true, autocomplete: 'email', hint: { text: "We'll send you an email with an account activation link." }
       = f.govuk_password_field :password, label: { text: 'Create password' }, hint: { text: t('password.hardness', length: @minimum_password_length) }
       = f.govuk_password_field :password_confirmation
+      = govuk_inset_text do 
+        p 
+          | By continuing, you accept the #{link_to "terms and conditions", static_path('terms-and-conditions')} and #{link_to "privacy policy", static_path('privacy-policy')}.
     = f.govuk_submit 'Continue'
 
 = render 'devise/shared/form_wrap'

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -1,3 +1,4 @@
+= link_to 'Back', root_path, class: 'govuk-back-link'
 - content_for :devise_form do
   = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
     = f.govuk_error_summary

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -4,7 +4,7 @@
     = f.govuk_fieldset legend: { text: 'Create a child development training account' } do
       p.govuk-body
         | Create an account to access training courses.
-      = f.govuk_email_field :email, autofocus: true, autocomplete: 'email', hint: { text: "We'll send you a message with a confirmation link. Please follow the link to activate your account." }
+      = f.govuk_email_field :email, autofocus: true, autocomplete: 'email', hint: { text: "We'll send you an email with an account activation link." }
       = f.govuk_password_field :password, label: { text: 'Create password' }, hint: { text: t('password.hardness', length: @minimum_password_length) }
       = f.govuk_password_field :password_confirmation
     = f.govuk_submit 'Continue'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,12 +16,12 @@ en:
               invalid: Your setting's postcode is invalid.
             email:
               blank: Enter an email address.
-              invalid: This email address is invalid.
+              invalid: Enter a valid email address.
             password:
               blank: Enter a password.
               too_short: Password must be at least 10 characters. # devise override
             password_confirmation:
-              confirmation: Confirmation doesn't match password.
+              confirmation: Sorry, your passwords don't match.
             ofsted_number:
               invalid: This Ofsted number is not recognised.
             setting_type:
@@ -43,12 +43,12 @@ en:
               invalid: Your setting's postcode is invalid.
             email:
               blank: Enter an email address.
-              invalid: This email address is invalid.
+              invalid: Enter a valid email address.
             password:
               blank: Enter a password.
               too_short: Password must be at least 10 characters. # devise override
             password_confirmation:
-              confirmation: Confirmation doesn't match password.
+              confirmation: Sorry, your passwords don't match.
             ofsted_number:
               invalid: This Ofsted number is not recognised.
   phase_banner_html: This is a new service, your %{feedback_link} will help us improve it.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,7 +234,7 @@ en:
         email: Email address
         password: Create a new password # /my-account/edit-password
         current_password: Enter your current password
-        password_confirmation: Re-type your new password
+        password_confirmation: Confirm password
         setting_type: Your setting type
         setting_type_other: Other setting
         postcode: Your setting's postcode

--- a/spec/system/forgotten_password_spec.rb
+++ b/spec/system/forgotten_password_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'User following forgotten password process', type: :system do
         fill_in 'Confirm your password', with: confirm_password
         click_on 'Reset password'
 
-        expect(page).to have_text("Confirmation doesn't match password.")
+        expect(page).to have_text("Sorry, your passwords don't match.")
       end
     end
   end

--- a/spec/system/registered_user/changing_password_spec.rb
+++ b/spec/system/registered_user/changing_password_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Registered user changing password', type: :system do
     visit '/my-account/edit-password'
     fill_in 'Enter your current password', with: 'StrongPassword123'
     fill_in 'Create a new password', with: password
-    fill_in 'Re-type your new password', with: password
+    fill_in 'Confirm password', with: password
   end
 
   context 'when cancelled' do

--- a/spec/system/sign_up_spec.rb
+++ b/spec/system/sign_up_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Sign up', type: :system do
     it 'prevents user enumeration exploit' do
       fill_in 'Email address', with: user.email
       fill_in 'Create password', with: 'StrongPassword123'
-      fill_in 'Re-type your new password', with: 'StrongPassword123'
+      fill_in 'Confirm password', with: 'StrongPassword123'
       click_button 'Continue'
 
       expect(page).to have_text('We sent the email to').and have_text(user.email)


### PR DESCRIPTION
Content changes for `Create an early year training account `page
- Added back link to the top of the page
- Updated hint text for email field
- Update field name for password confirmation field
- update email validation message
- update validation message for passwords not matching
- added terms & conditions and privacy policy to page