### PR TITLE
add links with correct styling

### DIFF
--- a/config/locales/static/accessibility_statement.yml
+++ b/config/locales/static/accessibility_statement.yml
@@ -14,6 +14,5 @@ en:
         * how this website meets the Web Content Accessibility Guidelines version 
         2.1 AA standard
 
-        If you have any feedback on the accessibility of this website, please 
-        [contact us](mailto:child.development.training@education.gov.uk?subject=Accessibility).
-
+        If you have any feedback on the accessibility of this website, please
+        [contact us](mailto:child.development.training@education.gov.uk?subject=Accessibility){:class="govuk-link"}.

--- a/config/locales/static/privacy_policy.yml
+++ b/config/locales/static/privacy_policy.yml
@@ -76,7 +76,7 @@ en:
 
         If you opted in to user research when you registered your interest or on the child development training course, you can also contact us to withdraw your consent  at any time. This will not affect your Child development training account, which you will still be able to access as normal.
 
-        To contact us, email [child.development.training@education.gov.uk](mailto://child.development.training@education.gov.uk){:class="govuk-link"}
+        To contact us, email [child.development.training@education.gov.uk](mailto://child.development.training@education.gov.uk){:class="govuk-link"}.
 
         If you have any concerns about the way we have handled your personal data, you have the right to raise them with the [Information Commissioner's Office](https://ico.org.uk/concerns){:target="_blank"}{:class="govuk-link"}.
         

--- a/config/locales/static/privacy_policy.yml
+++ b/config/locales/static/privacy_policy.yml
@@ -35,11 +35,11 @@ en:
 
         For our use of your personal data to be lawful, we need to meet one (or more) conditions in the data protection legislation. For this project, the relevant condition is:
 
-        &ldquo;Article 6(1)(e) UK GDPR, to perform a public task as part of our function as a department (sections 39, 40 and 43 of the Childcare Act 2006, together with Statutory Framework for the Early Years Foundation Stage, which is made in reliance on section 44 of the Childcare Act 2006)&rdquo;
+        "Article 6(1)(e) UK GDPR, to perform a public task as part of our function as a department (sections 39, 40 and 43 of the Childcare Act 2006, together with Statutory Framework for the Early Years Foundation Stage, which is made in reliance on section 44 of the Childcare Act 2006)"
 
         For the purpose of further research, another relevant condition is:
 
-        &ldquo;Condition 6.1(a): the individual(s) consented to me processing their personal data&rdquo;
+        "Condition 6.1(a): the individual(s) consented to me processing their personal data"
 
         ## Who we will make your personal data available to
 
@@ -57,13 +57,14 @@ en:
 
         ## Your data protection rights
 
-        You can [find more information about how the DfE handles personal information in the personal information charter](https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter){:target="_blank"}.
+        You can [find more information about how the DfE handles personal information in the personal information charter](https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter){:target="_blank"}{:class="govuk-link"}.
 
-        Under the Data Protection Act 2018, you are entitled to ask if we hold information relating to you and ask for a copy, by making a &lsquo;subject access request&rsquo;.
+        Under the Data Protection Act 2018, you are entitled to ask if we hold information relating to you and ask for a copy, by making a 'subject access request'.
 
-        [Contact us for further information including how to request your data](%{contact_us}){:target="_blank"}. Please refer to the &ldquo;Online child development training course&rdquo;. 
+        [Contact us for further information including how to request your data](%{contact_us}){:target="_blank"}{:class="govuk-link"}. Please refer to the "Online child development training course". 
         
-        Further information about your data protection rights appears on the [Information Commissioner&rsquo;s website](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/){:target="_blank"}. 
+        Further information about your data protection rights appears on the 
+        [Information Commissioner's website](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/){:target="_blank"}{:class="govuk-link"}.
 
         ## Withdrawal of consent and the right to lodge a complaint 
 
@@ -75,9 +76,9 @@ en:
 
         If you opted in to user research when you registered your interest or on the child development training course, you can also contact us to withdraw your consent  at any time. This will not affect your Child development training account, which you will still be able to access as normal.
 
-        To contact us, email [child.development.training@education.gov.uk](mailto://child.development.training@education.gov.uk). 
+        To contact us, email [child.development.training@education.gov.uk](mailto://child.development.training@education.gov.uk){:class="govuk-link"}
 
-        If you have any concerns about the way we have handled your personal data, you have the right to raise them with the [Information Commissioner&rsquo;s Office](https://ico.org.uk/concerns){:target="_blank"}.
+        If you have any concerns about the way we have handled your personal data, you have the right to raise them with the [Information Commissioner's Office](https://ico.org.uk/concerns){:target="_blank"}{:class="govuk-link"}.
         
         ## Last updated
 
@@ -85,4 +86,4 @@ en:
 
         ## Contact us
 
-        Please [contact us if you have any questions about how your personal information will be used](%{contact_us}){:target="_blank"}. Please refer to the &ldquo;Online child development training course&ldquo;.  
+        Please [contact us if you have any questions about how your personal information will be used](%{contact_us}){:target="_blank"}{:class="govuk-link"}. Please refer to the "Online child development training course".  

--- a/config/locales/static/terms_and_conditions.yml
+++ b/config/locales/static/terms_and_conditions.yml
@@ -115,7 +115,7 @@ en:
         * if it breaches copyright laws, contains sensitive personal data or 
         material that may be considered obscene or defamatory
 
-        <a class='govuk-link' href='mailto:child.development.training@education.gov.uk?subject=Request%20to%20remove%20content'>Contact us</a>
+        [Contact us](mailto:child.development.training@education.gov.uk?subject=Request%20to%20remove%20content){:class="govuk-link"}
         to ask for content to be removed. You'll need to send us the web address
         (URL) of the content and explain why you think it should be removed. We'll 
         reply to let you know whether we'll remove it.

--- a/config/locales/static/terms_and_conditions.yml
+++ b/config/locales/static/terms_and_conditions.yml
@@ -4,12 +4,12 @@ en:
     terms_and_conditions:
       heading: Terms and conditions
       content: |
-        This page and any pages it links to explains Child development training’s terms of use. 
+        This page and any pages it links to explains Child development training's terms of use. 
         You must agree to these to use Child development training. 
 
         ## Who we are
         Child development training is managed by the Department for Education (DfE). 
-        DfE will be referred to as ‘we’ from now on.
+        DfE will be referred to as 'we' from now on.
 
         ## Using Child development training
         By using Child development training, you agree to:
@@ -26,7 +26,7 @@ en:
 
         We welcome and encourage other websites to link to Child development training.
 
-        You must [contact us](mailto:child.development.training@education.gov.uk?subject=Request%20permission) 
+        You must [contact us](mailto:child.development.training@education.gov.uk?subject=Request%20permission){:class="govuk-link"}
         for permission if you want to say your website is associated with or 
         endorsed by Child development training or another government department 
         or agency.
@@ -38,7 +38,7 @@ en:
         organisations. We do not have any control over the content on these 
         websites.
 
-        We’re not responsible for:
+        We're not responsible for:
 
         * the protection of any information you give to these websites
         * any loss or damage that may come from your use of these websites, or 
@@ -70,11 +70,11 @@ en:
         * complete
         * free from bugs or viruses
 
-        We’re not liable for any loss or damage that may come from using Child 
+        We're not liable for any loss or damage that may come from using Child 
         development training. This includes:
 
         * any direct, indirect or consequential losses
-        * any loss or damage caused by civil wrongs (‘tort’, including negligence), 
+        * any loss or damage caused by civil wrongs ('tort', including negligence), 
         breach of contract or otherwise
         * the use of Child development training and any websites that are linked
         to or from it
@@ -108,24 +108,23 @@ en:
         ## Requests to remove content
 
         You can ask for content to be removed from Child development training.
-        We’ll remove content:
+        We'll remove content:
 
         * in order to comply with data protection legislation covering the 
         rights and freedoms of individuals
         * if it breaches copyright laws, contains sensitive personal data or 
         material that may be considered obscene or defamatory
 
-        [Contact us](mailto:child.development.training@education.gov.uk?subject=Request%20to%20remove%20content) 
-        to ask for content to be removed. You’ll need to send us the web address
-        (URL) of the content and explain why you think it should be removed. We’ll 
-        reply to let you know whether we’ll remove it.
+        <a class='govuk-link' href='mailto:child.development.training@education.gov.uk?subject=Request%20to%20remove%20content'>Contact us</a>
+        to ask for content to be removed. You'll need to send us the web address
+        (URL) of the content and explain why you think it should be removed. We'll 
+        reply to let you know whether we'll remove it.
 
 
         We remove content at our discretion in discussion with the department or 
-        agency responsible for it. You can still request information under the 
-        [Freedom of Information Act](https://www.gov.uk/make-a-freedom-of-information-request) 
-        and the [Data Protection Act](https://www.gov.uk/data-protection).
-
+        agency responsible for it. You can still request information under the
+        [Freedom of Information Act](https://www.gov.uk/make-a-freedom-of-information-request){:class="govuk-link"}
+        and the [Data Protection Act](https://www.gov.uk/data-protection){:class="govuk-link"}.
 
         ## Information about you and your visits to Child development training
 
@@ -142,22 +141,22 @@ en:
         malicious computer code or other forms of interference which can damage your 
         computer system.
 
-        We’re not responsible for any loss, disruption or damage to your data or 
+        We're not responsible for any loss, disruption or damage to your data or 
         computer system that might happen when you use Child development training.
 
         ## Viruses, hacking and other offences
 
         When using Child development training, you must not introduce viruses, 
-        trojans, worms, logic bombs or any other material that’s malicious or 
+        trojans, worms, logic bombs or any other material that's malicious or 
         technologically harmful.
 
         You must not try to gain unauthorised access to Child development training, 
-        the server on which it’s stored or any server, computer or database connected to it.
+        the server on which it's stored or any server, computer or database connected to it.
 
         You must not attack Child development training in any way. This includes 
         denial-of-service attacks.
 
-        We’ll report any attacks or attempts to gain unauthorised access to Child 
+        We'll report any attacks or attempts to gain unauthorised access to Child 
         development training to the relevant law enforcement authorities and share 
         information about you with them.
 
@@ -187,7 +186,7 @@ en:
         Please check these terms and conditions regularly. We can update them at 
         any time without notice.
 
-        You’ll agree to any changes if you continue to use Child development 
+        You'll agree to any changes if you continue to use Child development 
         training after the terms and conditions have been updated.
 
         Last updated 9 June 2022


### PR DESCRIPTION
Links on static pages have incorrect styling:
This PR fixes that on the:
- Accessibility statement page
- Privacy policy page
- Terms and conditions page