### PR TITLE
use correct email address for contact us links

### DIFF
--- a/config/locales/static/accessibility_statement.yml
+++ b/config/locales/static/accessibility_statement.yml
@@ -15,4 +15,4 @@ en:
         2.1 AA standard
 
         If you have any feedback on the accessibility of this website, please
-        [contact us](mailto:child.development.training@education.gov.uk?subject=Accessibility){:class="govuk-link"}.
+        [contact us](mailto:child-development.training@education.gov.uk?subject=Accessibility){:class="govuk-link"}.

--- a/config/locales/static/privacy_policy.yml
+++ b/config/locales/static/privacy_policy.yml
@@ -61,7 +61,7 @@ en:
 
         Under the Data Protection Act 2018, you are entitled to ask if we hold information relating to you and ask for a copy, by making a 'subject access request'.
 
-        [Contact us for further information including how to request your data](%{contact_us}){:target="_blank"}{:class="govuk-link"}. Please refer to the "Online child development training course". 
+        [Contact us for further information including how to request your data](mailto:child-development.training@education.gov.uk){:class="govuk-link"}. Please refer to the "Online child development training course".
         
         Further information about your data protection rights appears on the 
         [Information Commissioner's website](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/){:target="_blank"}{:class="govuk-link"}.
@@ -76,7 +76,7 @@ en:
 
         If you opted in to user research when you registered your interest or on the child development training course, you can also contact us to withdraw your consent  at any time. This will not affect your Child development training account, which you will still be able to access as normal.
 
-        To contact us, email [child.development.training@education.gov.uk](mailto://child.development.training@education.gov.uk){:class="govuk-link"}.
+        To contact us, email [child-development.training@education.gov.uk](mailto://child-development.training@education.gov.uk){:class="govuk-link"}.
 
         If you have any concerns about the way we have handled your personal data, you have the right to raise them with the [Information Commissioner's Office](https://ico.org.uk/concerns){:target="_blank"}{:class="govuk-link"}.
         
@@ -86,4 +86,4 @@ en:
 
         ## Contact us
 
-        Please [contact us if you have any questions about how your personal information will be used](%{contact_us}){:target="_blank"}{:class="govuk-link"}. Please refer to the "Online child development training course".  
+        Please [contact us if you have any questions about how your personal information will be used](mailto:child-development.training@education.gov.uk){:class="govuk-link"}. Please refer to the "Online child development training course".

--- a/config/locales/static/terms_and_conditions.yml
+++ b/config/locales/static/terms_and_conditions.yml
@@ -26,7 +26,7 @@ en:
 
         We welcome and encourage other websites to link to Child development training.
 
-        You must [contact us](mailto:child.development.training@education.gov.uk?subject=Request%20permission){:class="govuk-link"}
+        You must [contact us](mailto:child-development.training@education.gov.uk?subject=Request%20permission){:class="govuk-link"}
         for permission if you want to say your website is associated with or 
         endorsed by Child development training or another government department 
         or agency.
@@ -115,7 +115,7 @@ en:
         * if it breaches copyright laws, contains sensitive personal data or 
         material that may be considered obscene or defamatory
 
-        [Contact us](mailto:child.development.training@education.gov.uk?subject=Request%20to%20remove%20content){:class="govuk-link"}
+        [Contact us](mailto:child-development.training@education.gov.uk?subject=Request%20to%20remove%20content){:class="govuk-link"}
         to ask for content to be removed. You'll need to send us the web address
         (URL) of the content and explain why you think it should be removed. We'll 
         reply to let you know whether we'll remove it.


### PR DESCRIPTION
This PR fixes an issue with the wrong email/contact links being used on some static pages
Correct email link: mailto:child-development.training@education.gov.uk
