### PR TITLE
ER-311 all error messages to appear red error box

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,11 @@
   }
 }
 
+.govuk-notification-banner--error {
+  border-color: $govuk-error-colour;
+  background-color: $govuk-error-colour;
+}
+
 .light-grey-box {
   padding: govuk-spacing(5);
   margin-bottom: govuk-spacing(5);

--- a/app/views/formative_assessments/_assessment_banner.html.slim
+++ b/app/views/formative_assessments/_assessment_banner.html.slim
@@ -1,4 +1,4 @@
-div class= "govuk-notification-banner #{'govuk-notification-banner--success' if questionnaire.valid?}" role='alert' aria-labelledby='govuk-notification-banner-title' data-module='govuk-notification-banner'
+div class= "govuk-notification-banner #{questionnaire.valid? ? 'govuk-notification-banner--success' : 'govuk-notification-banner--error'}" role='alert' aria-labelledby='govuk-notification-banner-title' data-module='govuk-notification-banner'
   .govuk-notification-banner__header
     h2.govuk-notification-banner__title id= "govuk-notification-banner-title"
       = @questionnaire.valid? ? "That's right" : "That's not quite right"


### PR DESCRIPTION
[ER-311](https://dfedigital.atlassian.net/browse/ER-311)

The assessment banner uses the govuk notification banner component for
both correct and incorrect answers.  Updated to have a red outline and
red background on the title.

If error message componet is preferred, we can update for that, but for
consistency I recommend with staying with the notification banner as
modified.

![CleanShot 2022-07-07 at 15 15 02@2x](https://user-images.githubusercontent.com/6605/177795440-06bb91d8-c5c6-45a1-999b-72ac1c755d49.png)
