### PR TITLE
ER-307 ER-308 and ER-326 Adds markdown for questions

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -7,10 +7,10 @@ module ContentHelper
   end
 
   def govuk_heading(text, tag: :h1)
-    if text.present?
-      content_tag tag, class: 'govuk-heading-m' do
-        text
-      end
+    return if text.blank?
+
+    content_tag tag, class: 'govuk-heading-m' do
+      text
     end
   end
 

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -1,7 +1,17 @@
 module ContentHelper
   # @return [String] GDS formatted markdown as HTML
   def translate_markdown(markdown)
+    return if markdown.blank?
+
     raw GovspeakDecorator.translate_markdown(markdown)
+  end
+
+  def govuk_heading(text, tag: :h1)
+    if text.present?
+      content_tag tag, class: 'govuk-heading-m' do
+        text
+      end
+    end
   end
 
   def print_button(*additional_classes)

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -7,6 +7,10 @@ class Question < OpenStruct
     Question.new(question.merge(questionnaire: questionnaire, name: name))
   end
 
+  def legend_hidden?
+    label.nil?
+  end
+
   def to_partial_path
     !!multi_select ? 'shared/question_check_boxes' : 'shared/question_radio_buttons'
   end

--- a/app/views/confidence_checks/show.html.slim
+++ b/app/views/confidence_checks/show.html.slim
@@ -2,8 +2,7 @@
 / - if @questionnaire.module_item.page_number
 /   span.govuk-caption-l= t('page_number', ** @questionnaire.module_item  .page_number)
 
-h1
-  = @questionnaire.heading
+= govuk_heading(@questionnaire.heading)
 
 .gem-c-govspeak
   = translate_markdown(@questionnaire.body)

--- a/app/views/formative_assessments/show.html.slim
+++ b/app/views/formative_assessments/show.html.slim
@@ -1,8 +1,7 @@
 = render 'debug'
 - if @questionnaire.module_item.page_number
   span.govuk-caption-l= t('page_number', ** @questionnaire.module_item  .page_number)
-h1
-  = @questionnaire.heading
+= govuk_heading(@questionnaire.heading)
 .gem-c-govspeak
   = translate_markdown(@questionnaire.body)
 

--- a/app/views/questionnaires/show.html.slim
+++ b/app/views/questionnaires/show.html.slim
@@ -1,6 +1,6 @@
 = render 'debug'
 
-=govuk_heading(@questionnaire.heading)
+= govuk_heading(@questionnaire.heading)
 
 .gem-c-govspeak
   = translate_markdown(@questionnaire.body)

--- a/app/views/questionnaires/show.html.slim
+++ b/app/views/questionnaires/show.html.slim
@@ -1,7 +1,6 @@
 = render 'debug'
 
-h1
-  = @questionnaire.heading
+=govuk_heading(@questionnaire.heading)
 
 .gem-c-govspeak
   = translate_markdown(@questionnaire.body)

--- a/app/views/shared/_question_check_boxes.html.slim
+++ b/app/views/shared/_question_check_boxes.html.slim
@@ -1,4 +1,5 @@
-= f.govuk_check_boxes_fieldset question.name, legend: { text: question.label, size: "m" } do
+= f.govuk_check_boxes_fieldset question.name, legend: {text: translate_markdown(question.label), hidden: question.legend_hidden?} do
+  = translate_markdown(question.body)
   - question.answers.each do |option|
     - checked = answers_checkbox(question.questionnaire.user_answers, option[0])
     - disabled = disable_checkbox(@questionnaire)

--- a/app/views/shared/_question_radio_buttons.html.slim
+++ b/app/views/shared/_question_radio_buttons.html.slim
@@ -1,4 +1,5 @@
-= f.govuk_radio_buttons_fieldset question.name, legend: { text: question.label, size: "m" } do
+= f.govuk_radio_buttons_fieldset question.name, legend: { text: translate_markdown(question.label), hidden: question.legend_hidden? } do
+  = translate_markdown(question.body)
   - question.answers.each do |option|
     - checked = answers_checkbox(question.questionnaire.user_answers, option[0])
     - disabled = disable_checkbox(@questionnaire)

--- a/app/views/summative_assessments/show.html.slim
+++ b/app/views/summative_assessments/show.html.slim
@@ -1,8 +1,7 @@
 = render 'debug'
 / - if @questionnaire.module_item.page_number
 /   span.govuk-caption-l= t('page_number', ** @questionnaire.module_item  .page_number)
-h1
-  = @questionnaire.heading
+= govuk_heading(@questionnaire.heading)
 
 .gem-c-govspeak
   = translate_markdown(@questionnaire.body)

--- a/app/views/summative_assessments/show.html.slim
+++ b/app/views/summative_assessments/show.html.slim
@@ -1,6 +1,7 @@
 = render 'debug'
 / - if @questionnaire.module_item.page_number
 /   span.govuk-caption-l= t('page_number', ** @questionnaire.module_item  .page_number)
+
 = govuk_heading(@questionnaire.heading)
 
 .gem-c-govspeak

--- a/data/questionnaires/alpha.yml
+++ b/data/questionnaires/alpha.yml
@@ -5,7 +5,14 @@ alpha:
     questions:
       alpha_question_one:
         multi_select: false
-        label: Question One Select from following
+        body: |
+          Question One Select from following
+
+          Describe with a list 
+            - one
+            - two
+            - three
+            - four
         assessment_summary: You selected the correct answer
         assessment_fail_summary: Unfortunatly you have got this one wrong
         answers:
@@ -17,7 +24,10 @@ alpha:
     questions:
       alpha_question_two:
         multi_select: true
-        label: Question Two Select from following
+        body: |
+          Question Two Select from following
+
+          **this is really important**
         assessment_summary: You selected the correct answer's
         assessment_fail_summary: Unfortunatly you have got this one wrong
         answers:
@@ -30,7 +40,8 @@ alpha:
     questions:
       alpha_question_three:
         multi_select: true
-        label: Question Three Select from following
+        body: |
+          Question Three Select from following
         assessment_summary: You selected the correct answer's
         assessment_fail_summary: Unfortunatly you have got this one wrong
         answers:

--- a/data/questionnaires/brain-development-and-how-children-learn.yml
+++ b/data/questionnaires/brain-development-and-how-children-learn.yml
@@ -1,7 +1,6 @@
 ---
 brain-development-and-how-children-learn:
   2-1-1-1b:
-    content:
     questions:
       1_what_brain_area:
         multi_select: false 


### PR DESCRIPTION
Using markdown you can now have the following:
 - bullet points in a question
 - line breaks in a questions

You can also now replace the `label` attribute (which is used for the **legend** of the question) with a `body` attribute, with no specific styling beyond what is available in markdown.

[ER-307](https://dfedigital.atlassian.net/browse/ER-307)

[ER-308](https://dfedigital.atlassian.net/browse/ER-308)

[ER-326](https://dfedigital.atlassian.net/browse/ER-326)