### PR TITLE
Update lead line for course criteria

### DIFF
--- a/app/views/training_modules/index.html.slim
+++ b/app/views/training_modules/index.html.slim
@@ -38,7 +38,7 @@ p.govuk-body
         - accordion.section(heading_text: "Module #{pos}: #{mod.title}", summary_text: mod.description) do
           .gem-c-govspeak= translate_markdown(mod.objective)
           h2 What you&rsquo;ll learn 
-          p.govuk_body On completion of this module you will be able to:
+          p.govuk_body This module will cover:
           .gem-c-govspeak= translate_markdown(mod.criteria)
 
       - accordion.section(heading_text: t('experts.heading'), summary_text: t('experts.summary')) do


### PR DESCRIPTION
[ER-325](https://dfedigital.atlassian.net/browse/ER-325)

The certificate and the course overview page use the same
bullet list of course criteria - match the grammer of the
list.