### PR TITLE
Revert "Full reload for turbo in rails to support third party library"

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -6,8 +6,6 @@ html.govuk-template lang="en"
     = render 'layouts/analytics_header' if cookies[:track_analytics] == 'Yes'
     meta content="width=device-width,initial-scale=1" name="viewport" /
     meta name="robots" content="noindex,nofollow" /
-    / https://turbo.hotwired.dev/handbook/drive#ensuring-specific-pages-trigger-a-full-reload
-    meta name="turbo-visit-control" content="reload" /
     = tag :meta, property: 'og:image', content: asset_path('images/govuk-opengraph-image.png')
     = csrf_meta_tags
     = csp_meta_tag
@@ -18,7 +16,7 @@ html.govuk-template lang="en"
     = favicon_link_tag asset_path('images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180'
 
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
-    = javascript_include_tag "application", "data-turbo-track": "reload", defer: true, 'data-turbolinks-eval': false
+    = javascript_include_tag "application", "data-turbo-track": "reload", defer: true
   body.govuk-template__body.govuk-body
     script
       | document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');


### PR DESCRIPTION
Reverts DFE-Digital/early-years-foundation-recovery#215

Error messages for forms (handled by turbo) were not being shown.  Reverting to allow error messages.