### PR TITLE
ER-323 Fix interruption page

### DIFF
--- a/app/models/content_page.rb
+++ b/app/models/content_page.rb
@@ -35,4 +35,8 @@ class ContentPage
   def formative?
     module_item.parent.formative?
   end
+
+  def summative?
+    module_item.parent.summative?
+  end
 end

--- a/app/models/training_module.rb
+++ b/app/models/training_module.rb
@@ -23,6 +23,11 @@ class TrainingModule < YamlBase
     @formative ||= ModuleItem.where_type(name, 'formative_assessment').any?
   end
 
+  # @return [Boolean]
+  def summative?
+    @summative ||= ModuleItem.where_type(name, 'summative_assessment').any?
+  end
+
   # collections -------------------------
 
   # @return [Array<Questionnaire>]

--- a/app/views/content_pages/interruption_page.html.slim
+++ b/app/views/content_pages/interruption_page.html.slim
@@ -4,11 +4,8 @@
   .interrupt-panel.govuk-grid-column-full
     h1 What to expect during the training
     .gem-c-govspeak
-      - if @model.formative?
-        = translate_markdown t('interruption.formative')
-      - else
-        = translate_markdown t('interruption.summative')
-
+      = translate_markdown t('interruption.formative') if @model.formative
+      = translate_markdown t('interruption.summative') if @model.summative
       = translate_markdown t('interruption.common')
 
     hr class='govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-4'

--- a/app/views/content_pages/interruption_page.html.slim
+++ b/app/views/content_pages/interruption_page.html.slim
@@ -4,8 +4,8 @@
   .interrupt-panel.govuk-grid-column-full
     h1 What to expect during the training
     .gem-c-govspeak
-      = translate_markdown t('interruption.formative') if @model.formative
-      = translate_markdown t('interruption.summative') if @model.summative
+      = translate_markdown t('interruption.formative') if @model.formative?
+      = translate_markdown t('interruption.summative') if @model.summative?
       = translate_markdown t('interruption.common')
 
     hr class='govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-4'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,11 +166,6 @@ en:
       You can sign out or close the browser at any time without losing your progress.
       When you next sign in, you can restart from where you left off.
 
-      ## Get a certificate of achievement
-
-      At the end of this module, you will be able to download a certificate of
-      achievement, showing what you have learned.
-
       ## Reflect on your learning with practitioner prompts
 
       You will see practitioner prompts throughout the course.


### PR DESCRIPTION
[ER-232](https://dfedigital.atlassian.net/browse/ER-323)

Make the formative/summative sections of the interruption page independent.

~~I'm leaving the "Get a certificate of achievement" section in for now - it's in the story but not in the google doc provided by Laura (https://docs.google.com/document/d/1_DDH2mNEyegGHCp_Xy2bQBYDe_Khj2nNKpN2Fjfoxtw/edit?usp=sharing) - the actual text can be managed by the content team if the logic is now correct.~~

Laura has requested it be removed.