### PR TITLE
ER-289 Update error message for confirmation already confirmed

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -69,8 +69,8 @@ en:
       unlocked: "Your account has been unlocked successfully. Please sign in to continue."
   errors:
     messages:
-      already_confirmed: "was already confirmed, please try signing in"
-      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      already_confirmed: "Email address already confirmed, please try signing in."
+      confirmation_period_expired: "Email address needs to be confirmed within %{period}, please request a new one"
       expired: "has expired, please request a new one"
       not_found: "not found"
       not_locked: "was not locked"


### PR DESCRIPTION
[ER-289](https://dfedigital.atlassian.net/browse/ER-289)

Update the error message show when an already confirmed email address is confirmed again.

![CleanShot 2022-08-17 at 10 45 44@2x](https://user-images.githubusercontent.com/6605/185088297-995f101f-b44b-4389-9e4a-54170fba8f58.png)


