### PR TITLE
Er 431 whats new page

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -5,7 +5,13 @@ protected
 
   def after_sign_in_path_for(resource)
     if resource.registration_complete?
-      my_learning_path
+      if resource.display_whats_new
+        resource.display_whats_new = false
+        resource.save
+        static_path('whats-new')
+      else
+        my_learning_path
+      end
     else
       extra_registrations_path
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -7,7 +7,7 @@ protected
     if resource.registration_complete?
       if resource.display_whats_new
         resource.display_whats_new = false
-        resource.save
+        resource.save!
         static_path('whats-new')
       else
         my_learning_path

--- a/app/views/static/whats_new.html.slim
+++ b/app/views/static/whats_new.html.slim
@@ -1,0 +1,7 @@
+.govuk-grid-row
+  .govuk-grid-column-two-thirds-from-desktop
+    =govuk_back_link(href: url_for(:back))
+
+    h1 = t(".heading")
+
+    .content = translate_markdown(t(".content"))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -343,3 +343,4 @@ en:
         accessibility-statement: Accessibility statement
         other-problems-signing-in: Other problems signing in
         terms-and-conditions: Terms and conditions
+        whats-new: What's new

--- a/config/locales/static/whats_new.yml
+++ b/config/locales/static/whats_new.yml
@@ -1,0 +1,7 @@
+---
+en:
+  static:
+    whats_new:
+      heading: What's new
+      content: |
+        hello

--- a/config/locales/static/whats_new.yml
+++ b/config/locales/static/whats_new.yml
@@ -2,6 +2,70 @@
 en:
   static:
     whats_new:
-      heading: What's new
+      heading: What's new in the training
       content: |
-        hello
+        <div class="govuk-inset-text">
+          We’ve added a few things since you were last here. 
+        </div>
+
+        <h2>Videos</h2>
+
+        We’ve added videos to modules 1, 2 and 3. These videos will enhance your 
+        understanding of a specific area of child development and how it applies 
+        to your practice. Each video has captions and a transcript. You can look 
+        out for these videos as you go through the training.
+
+        <h2>In your setting prompts</h2>
+
+        The information icon highlights practical tips to use in your setting. 
+
+        $INFO
+
+        You should provide activities that require children to share of resources
+        and take turns. This will help them to develop to promote problem solving
+        and cooperation skills. 
+
+        $INFO
+
+        <h2>Reflection points</h2>
+
+        We’ve replaced practitioner prompts with reflection points. This is  a
+        chance to reflect on what you’ve learned and how it applies to your practice.
+
+        $BRAIN
+
+        Reflect on what you have read about supporting children’s individual development.
+
+        Consider the following questions:
+        <ul>
+          <li>What information do you gather to understand each child’s starting point?</li>
+          <li>Who do you involve?</li>
+        </ul>
+
+        $BRAIN
+
+        <h2>Learning log</h2>
+
+        You now have a space to make notes on reflection points. You can view all
+        your notes in your personal learning log. You can access your learning log
+        from the main menu and from any page where the learning log appears.
+
+        <div class="govuk-prompt govuk-prompt__grey">
+          <div class="govuk-prompt__icon">
+            <i style="color:white;" class="fa-solid fa-pencil icon fa-2x"></i>
+          </div>
+          <h2 class="govuk-heading-m">Add to your learning log</h2>
+          <p class="govuk-body">Use this space to make notes on the reflection point. Do not enter any personal or sensitive information like children's names.</p>
+          <p class="govuk-body">All your notes will be added to your personal learning log.</p>
+    
+        
+          <div class="govuk-form-group govuk-log-text">
+          <label class="govuk-label" for="label-as-page-heading">
+            Your notes
+          </label>
+          <textarea class="govuk-textarea govuk-js-character-count" id="label-as-page-heading" name="log-reflect-3" rows="5" aria-describedby="label-as-page-heading-info"></textarea>
+          </div>
+        </div>
+        
+        <a class="govuk-button" href="my-modules">Continue to My modules</a>
+        

--- a/db/migrate/20220926104904_add_display_whats_new_to_users.rb
+++ b/db/migrate/20220926104904_add_display_whats_new_to_users.rb
@@ -1,0 +1,5 @@
+class AddDisplayWhatsNewToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :display_whats_new, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_23_134456) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_26_104904) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -111,6 +111,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_23_134456) do
     t.string "unlock_token"
     t.string "setting_type"
     t.string "setting_type_other"
+    t.boolean "display_whats_new", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/lib/tasks/whats_new.rake
+++ b/lib/tasks/whats_new.rake
@@ -1,0 +1,16 @@
+namespace :db do
+  desc 'Set all users display_whats_new to true'
+  task display_whats_new: :environment do
+    number_updated = 0
+    total_records = 0
+
+    User.all.map do |user|
+      user.display_whats_new = true
+      user.save
+
+      number_updated += 1 if user.display_whats_new == true
+      total_records += 1
+    end
+    p "Updated #{number_updated} of #{total_records} records"
+  end
+end

--- a/lib/tasks/whats_new.rake
+++ b/lib/tasks/whats_new.rake
@@ -6,7 +6,7 @@ namespace :db do
 
     User.all.map do |user|
       user.display_whats_new = true
-      user.save
+      user.save!
 
       number_updated += 1 if user.display_whats_new == true
       total_records += 1

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     end
 
     trait :display_whats_new do
-      display_whats_new {true}
+      display_whats_new { true }
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -24,9 +24,5 @@ FactoryBot.define do
     trait :display_whats_new do
       display_whats_new {true}
     end
-    
-    trait :dont_display_whats_new do
-      display_whats_new {false}
-    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,5 +20,13 @@ FactoryBot.define do
       registered
       ofsted_number { 'EY123456' }
     end
+
+    trait :display_whats_new do
+      display_whats_new {true}
+    end
+    
+    trait :dont_display_whats_new do
+      display_whats_new {false}
+    end
   end
 end

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -61,4 +61,30 @@ RSpec.describe 'Sign in', type: :system do
         .and have_text('Enter a valid email address and password. Your account will be locked after 5 unsuccessful attempts. We will email you instructions to unlock your account.')
     end
   end
+
+  context "when what's new page has not been viewed" do
+    let(:user) { create :user, :completed, :display_whats_new }
+
+    it "visits what's new page after sign in" do
+      fill_in 'Email address', with: user.email
+      fill_in 'Password', with: user.password
+      click_button 'Sign in'
+
+      expect(page).to have_current_path('/whats_new')
+    end
+  end
+  
+  context "when what's new page has been viewed" do
+    let(:user) { create :user, :completed, :dont_display_whats_new }
+    
+    it "does not visit what's new page after sign in" do
+      fill_in 'Email address', with: user.email
+      fill_in 'Password', with: user.password
+      click_button 'Sign in'
+
+      expect(page).not_to have_current_path('/whats_new')
+    end
+  end
+
+
 end

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -61,30 +61,4 @@ RSpec.describe 'Sign in', type: :system do
         .and have_text('Enter a valid email address and password. Your account will be locked after 5 unsuccessful attempts. We will email you instructions to unlock your account.')
     end
   end
-
-  context "when what's new page has not been viewed" do
-    let(:user) { create :user, :completed, :display_whats_new }
-
-    it "visits what's new page after sign in" do
-      fill_in 'Email address', with: user.email
-      fill_in 'Password', with: user.password
-      click_button 'Sign in'
-
-      expect(page).to have_current_path('/whats_new')
-    end
-  end
-  
-  context "when what's new page has been viewed" do
-    let(:user) { create :user, :completed, :dont_display_whats_new }
-    
-    it "does not visit what's new page after sign in" do
-      fill_in 'Email address', with: user.email
-      fill_in 'Password', with: user.password
-      click_button 'Sign in'
-
-      expect(page).not_to have_current_path('/whats_new')
-    end
-  end
-
-
 end

--- a/spec/system/whats_new_page_spec.rb
+++ b/spec/system/whats_new_page_spec.rb
@@ -8,20 +8,20 @@ RSpec.describe 'Whats new page', type: :system do
     visit '/users/sign-in'
   end
 
-  context 'exisiting user' do
+  context 'when exisiting user' do
     before do
       fill_in 'Email address', with: user.email
       fill_in 'Password', with: user.password
       click_button 'Sign in'
     end
 
-    context "when what's new page has not been viewed" do
+    context "and 'whats new' page has not been viewed" do
       it "visits what's new page after sign in" do
         expect(page).to have_current_path '/whats-new'
       end
     end
 
-    context "when what's new page has been viewed" do
+    context "and 'whats new' page has been viewed" do
       let(:user) { create :user, :completed, :display_whats_new }
 
       it "does not visit what's new page after sign in" do

--- a/spec/system/whats_new_page_spec.rb
+++ b/spec/system/whats_new_page_spec.rb
@@ -3,40 +3,40 @@ require 'rails_helper'
 RSpec.describe 'Whats new page', type: :system do
   let(:user) { create :user, :completed, :display_whats_new }
   let(:new_user) { create :user, :completed }
-  
-  before do 
+
+  before do
     visit '/users/sign-in'
   end
-  
+
   context 'exisiting user' do
     before do
       fill_in 'Email address', with: user.email
       fill_in 'Password', with: user.password
       click_button 'Sign in'
     end
-    
+
     context "when what's new page has not been viewed" do
       it "visits what's new page after sign in" do
         expect(page).to have_current_path '/whats-new'
       end
     end
-    
+
     context "when what's new page has been viewed" do
       let(:user) { create :user, :completed, :display_whats_new }
-      
+
       it "does not visit what's new page after sign in" do
         click_on 'Sign out'
-        
+
         visit '/users/sign-in'
         fill_in 'Email address', with: user.email
         fill_in 'Password', with: user.password
         click_button 'Sign in'
-        
+
         expect(page).not_to have_current_path '/whats_new'
       end
     end
   end
-  
+
   context 'when new user is created' do
     it "does not visit what's new page" do
       fill_in 'Email address', with: new_user.email

--- a/spec/system/whats_new_page_spec.rb
+++ b/spec/system/whats_new_page_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Whats new page', type: :system do
     
     context "when what's new page has not been viewed" do
       it "visits what's new page after sign in" do
-        expect(page).to have_current_path '/whats_new'
+        expect(page).to have_current_path '/whats-new'
       end
     end
     
@@ -25,7 +25,7 @@ RSpec.describe 'Whats new page', type: :system do
       let(:user) { create :user, :completed, :display_whats_new }
       
       it "does not visit what's new page after sign in" do
-        click_button 'Sign out'
+        click_on 'Sign out'
         
         visit '/users/sign-in'
         fill_in 'Email address', with: user.email

--- a/spec/system/whats_new_page_spec.rb
+++ b/spec/system/whats_new_page_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe 'Whats new page', type: :system do
+  let(:user) { create :user, :completed, :display_whats_new }
+  let(:new_user) { create :user, :completed }
+  
+  before do 
+    visit '/users/sign-in'
+  end
+  
+  context 'exisiting user' do
+    before do
+      fill_in 'Email address', with: user.email
+      fill_in 'Password', with: user.password
+      click_button 'Sign in'
+    end
+    
+    context "when what's new page has not been viewed" do
+      it "visits what's new page after sign in" do
+        expect(page).to have_current_path '/whats_new'
+      end
+    end
+    
+    context "when what's new page has been viewed" do
+      let(:user) { create :user, :completed, :display_whats_new }
+      
+      it "does not visit what's new page after sign in" do
+        click_button 'Sign out'
+        
+        visit '/users/sign-in'
+        fill_in 'Email address', with: user.email
+        fill_in 'Password', with: user.password
+        click_button 'Sign in'
+        
+        expect(page).not_to have_current_path '/whats_new'
+      end
+    end
+  end
+  
+  context 'when new user is created' do
+    it "does not visit what's new page" do
+      fill_in 'Email address', with: new_user.email
+      fill_in 'Password', with: new_user.password
+      click_button 'Sign in'
+
+      expect(page).not_to have_current_path '/whats_new'
+    end
+  end
+end


### PR DESCRIPTION
Ticket: [ER-431](https://dfedigital.atlassian.net/browse/ER-431)

- Add `display_whats_new` column to `users` table
- Add rake task to make each `display_whats_new` column to be true
- Add `whats-new` page to be displayed once after logging in

To do:
- [ ] Add practitioner prompt styling to `whats-new` page