### PR TITLE
ER-411 Fix notification banner styling and content

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@
 @import "./govspeak";
 @import "./card";
 @import "./prompt";
+@import "./question";
 @import "./interruption";
 @import "./print-link";
 @import "./quote";

--- a/config/initializers/govspeak.rb
+++ b/config/initializers/govspeak.rb
@@ -4,9 +4,6 @@ GOVSPEAK_TEMPLATES = {
   vimeo: Slim::Template.new('app/views/govspeak/_embedded_video.html.slim'),
 }.freeze
 
-# preload
-I18n.load_path += Dir[Rails.root.join('config/locales/**/*.yml')]
-
 # Custom Practitioner Prompts
 %i[info book brain].each do |icon|
   prompt_name = "prompt-#{icon}"

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -2,8 +2,3 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :request
 end
-
-# OPTIMIZE: I18n load order in specs as a result of custom Govspeak extensions.
-# Ensure our custom translations are used (config/locales/devise.en.yml)
-# because Devise is appending its defaults to I18n.load_path in the test suite.
-I18n.load_path += Dir[Rails.root.join('config/locales/devise.en.yml')]


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/ER-411

- remove change to I18n load path in govspeak as redundant
- include omitted styling for notification banners
- banner styling ensures paragraphs have spaces defined in by govspeak