### PR TITLE
Revert to using a manual task run on deployment

### DIFF
--- a/lib/fill_page_views.rb
+++ b/lib/fill_page_views.rb
@@ -26,6 +26,7 @@ class FillPageViews
         end
 
         skipped = 0
+        page = progress.furthest_page.name
 
         mod.module_items.each do |item|
           break if item.eql?(progress.furthest_page.next_item)
@@ -45,7 +46,7 @@ class FillPageViews
           end
         end
 
-        log "user [#{user.id}] module [#{mod.id}] - [#{skipped}] skipped before page [#{progress.furthest_page.id}]"
+        log "user [#{user.id}] module [#{mod.id}] - [#{skipped}] skipped before page [#{page}]"
       end
     end
   end

--- a/lib/tasks/post.rake
+++ b/lib/tasks/post.rake
@@ -5,5 +5,3 @@ namespace :post do
     FillPageViews.new.call
   end
 end
-
-task post_release: ['db:prepare', 'post:content']

--- a/spec/lib/fill_page_views_spec.rb
+++ b/spec/lib/fill_page_views_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe FillPageViews do
         expect(event).to be_nil
       end
 
-      expect { service.call }.to output(/user \[\d+\] module \[\d+\] - \[2\] skipped before page \[10\]/).to_stdout_from_any_process
+      expect { service.call }.to output(/user \[\d+\] module \[\d+\] - \[2\] skipped before page \[1-2\]/).to_stdout_from_any_process
 
       expect(Ahoy::Event.count).to be 10
 
@@ -75,7 +75,7 @@ RSpec.describe FillPageViews do
         expect(event).to be_nil
       end
 
-      expect { service.call }.to output(/user \[\d+\] module \[\d+\] - \[5\] skipped before page \[28\]/).to_stdout_from_any_process
+      expect { service.call }.to output(/user \[\d+\] module \[\d+\] - \[5\] skipped before page \[1-3-4\]/).to_stdout_from_any_process
 
       expect(Ahoy::Event.count).to be 28
 

--- a/terraform/workspace-variables/development.tfvars
+++ b/terraform/workspace-variables/development.tfvars
@@ -1,3 +1,2 @@
-paas_app_environment       = "development"
-paas_cf_space_name         = "ey-recovery-staging"
-paas_web_app_start_command = "bundle exec rails post_release && bundle exec rails server -b 0.0.0.0"
+paas_app_environment = "development"
+paas_cf_space_name   = "ey-recovery-staging"

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -1,3 +1,4 @@
 paas_app_environment       = "staging"
 paas_cf_space_name         = "ey-recovery-staging"
 paas_web_app_start_command = "bundle exec rails post_release && bundle exec rails server -b 0.0.0.0"
+paas_web_app_start_timeout = 600

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -1,4 +1,3 @@
 paas_app_environment       = "staging"
 paas_cf_space_name         = "ey-recovery-staging"
 paas_web_app_start_command = "bundle exec rails post_release && bundle exec rails server -b 0.0.0.0"
-paas_web_app_start_timeout = 600

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -1,3 +1,2 @@
-paas_app_environment       = "staging"
-paas_cf_space_name         = "ey-recovery-staging"
-paas_web_app_start_command = "bundle exec rails post_release && bundle exec rails server -b 0.0.0.0"
+paas_app_environment = "staging"
+paas_cf_space_name   = "ey-recovery-staging"


### PR DESCRIPTION
Release candidate 0.0.25 exceeded timeout due to volume of users (120) and events (16812).
Either an excessive timeout value fourfold greater, or concurrent batches, would be needed for this to be viable at scale.
In the meantime we will run the task on demand.