### PR TITLE
ER-469 cancel buttons on my account page not styled correctly

### DIFF
--- a/app/views/user/edit_email.html.slim
+++ b/app/views/user/edit_email.html.slim
@@ -10,4 +10,4 @@
 
       = form.govuk_submit t('links.save')
 
-      p= link_to 'Cancel', user_path
+      p= govuk_link_to 'Cancel', user_path

--- a/app/views/user/edit_name.html.slim
+++ b/app/views/user/edit_name.html.slim
@@ -9,4 +9,4 @@
         = form.govuk_text_field :last_name
         = form.govuk_submit t('links.save')
 
-        p= link_to 'Cancel', user_path
+        p= govuk_link_to 'Cancel', user_path

--- a/app/views/user/edit_ofsted_number.html.slim
+++ b/app/views/user/edit_ofsted_number.html.slim
@@ -6,4 +6,4 @@
         = form.govuk_text_field :ofsted_number, autofocus: true
         = form.govuk_submit t('links.save')
 
-        p= link_to 'Cancel', user_path
+        p= govuk_link_to 'Cancel', user_path

--- a/app/views/user/edit_password.html.slim
+++ b/app/views/user/edit_password.html.slim
@@ -13,5 +13,5 @@
 
       = f.govuk_submit t('links.save')
 
-      p= link_to 'Cancel', user_path
+      p= govuk_link_to 'Cancel', user_path
 

--- a/app/views/user/edit_postcode.html.slim
+++ b/app/views/user/edit_postcode.html.slim
@@ -6,4 +6,4 @@
         = form.govuk_text_field :postcode, autofocus: true
         = form.govuk_submit t('links.save')
 
-        p= link_to 'Cancel', user_path
+        p= govuk_link_to 'Cancel', user_path

--- a/app/views/user/edit_setting_type.html.slim
+++ b/app/views/user/edit_setting_type.html.slim
@@ -10,5 +10,5 @@
           = f.govuk_text_field :setting_type_other, label: { text: 'Other setting'}
       = f.govuk_submit t('links.save')
 
-      p= link_to 'Cancel', user_path
+      p= govuk_link_to 'Cancel', user_path
 


### PR DESCRIPTION
Ticket: [ER-469](https://dfedigital.atlassian.net/browse/ER-469)

- change class to govuk_link_to so it is styled correctly

Screenshots:
Visited link:
<img width="404" alt="image" src="https://user-images.githubusercontent.com/13471320/195099259-0226129e-0d8a-45a4-8a91-27ab592bcc99.png">

Hover link:
![image](https://user-images.githubusercontent.com/13471320/195099695-3396ffae-a9ef-4b85-9db1-f0f06918a0a7.png)

