### PR TITLE
Bump gem versions

### DIFF
--- a/.github/workflows/ci-docker-compose.yml
+++ b/.github/workflows/ci-docker-compose.yml
@@ -17,8 +17,8 @@ jobs:
 
     steps:
       -
-        name: Check out code
-        uses: actions/checkout@v2
+        name: Checkout Code
+        uses: actions/checkout@v3
       -
         name: Build application Docker image
         run: docker-compose -f docker-compose.yml -f docker-compose.test.yml --project-name recovery build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.1.2
-      -
-        name: Set up ruby gem cache
-        uses: actions/cache@v3
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
+          bundler-cache: true
       -
         name: Install Rubygems
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
 
     steps:
       -
-        name: Checkout code
-        uses: actions/checkout@v2
+        name: Checkout Code
+        uses: actions/checkout@v3
       -
         name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           ruby-version: 3.1.2
       -
         name: Set up ruby gem cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -67,7 +67,7 @@ jobs:
         name: Prepare test database
         run: bin/rails db:prepare
         env:
-          NOTIFY_API_KEY: ""
+          NOTIFY_API_KEY: foo
       -
         name: Run test suite
         run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,7 @@ jobs:
           bundler-cache: true
       -
         name: Install Rubygems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 20 --retry 3
+        run: bundle install --jobs 20 --retry 3
       -
         name: Use Node.js 18
         uses: actions/setup-node@v3

--- a/.github/workflows/content.yml
+++ b/.github/workflows/content.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       -
         name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       -

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       -
         name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         # with:
         #   ref: ${{ github.sha }}
       -

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       -
         name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Use Node.js 18
         uses: actions/setup-node@v3

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       -
         name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref || github.ref_name }}
       -

--- a/.github/workflows/qa-docker-compose.yml
+++ b/.github/workflows/qa-docker-compose.yml
@@ -38,8 +38,8 @@ jobs:
 
     steps:
       -
-        name: Check out code
-        uses: actions/checkout@v2
+        name: Checkout Code
+        uses: actions/checkout@v3
       -
         name: Build Docker images
         run: docker-compose -f docker-compose.yml -f docker-compose.qa.yml --project-name recovery build

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -48,7 +48,7 @@ jobs:
           ruby-version: 3.1.0
       -
         name: Set up ruby gem cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -45,15 +45,8 @@ jobs:
         name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1.0
-      -
-        name: Set up ruby gem cache
-        uses: actions/cache@v3
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
+          ruby-version: 3.1.2
+          bundler-cache: true
       -
         name: Install Rubygems
         run: |

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -49,9 +49,7 @@ jobs:
           bundler-cache: true
       -
         name: Install Rubygems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 20 --retry 3
+        run: bundle install --jobs 20 --retry 3
       -
         name: Run test suite against firefox
         env:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -39,8 +39,8 @@ jobs:
 
     steps:
       -
-        name: Checkout code
-        uses: actions/checkout@v2
+        name: Checkout Code
+        uses: actions/checkout@v3
       -
         name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       -
         name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref || github.ref_name }}
       -

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       -
         name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       -

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -21,8 +21,8 @@ jobs:
 
     steps:
       -
-        name: Checkout code
-        uses: actions/checkout@v2
+        name: Checkout Code
+        uses: actions/checkout@v3
       - # TODO: replace with "docker/build-push-action@v2" for caching
         name: Build image from Dockerfile
         run: |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faker (2.23.0)
+    faker (3.0.0)
       i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     foreman (0.87.2)
@@ -176,7 +176,7 @@ GEM
     govuk_personalisation (0.12.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (31.2.0)
+    govuk_publishing_components (32.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -451,7 +451,7 @@ GEM
       backports (>= 3.18)
       rainbow
       yard
-    zeitwerk (2.6.2)
+    zeitwerk (2.6.4)
 
 PLATFORMS
   aarch64-linux-musl


### PR DESCRIPTION
- fix dependabot PRs struggling by not seeing the blank value for Notify's API key when prepping the DB
- update the workflow action versions still causing deprecation warnings
- bulk update some gems to observe dependabot's reaction 