### PR TITLE
Deploy after manual update to db service

### DIFF
--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -1,3 +1,4 @@
-paas_app_environment       = "production"
-paas_cf_space_name         = "ey-recovery"
-paas_postgres_service_plan = "small-ha-13"
+paas_app_environment          = "production"
+paas_cf_space_name            = "ey-recovery"
+paas_postgres_service_plan    = "medium-ha-13"
+paas_postgres_create_timeout  = "20m"


### PR DESCRIPTION
Run `cf update-service ey-recovery-db -p medium-ha-13` before next production deployment to ensure scaling succeeds.

Altering the size of the DB service in Terraform fails to deploy because it also attempts to modify the included extensions.
https://github.com/DFE-Digital/early-years-foundation-recovery/actions/runs/3488314182/jobs/5836980476
```
 # module.paas.cloudfoundry_service_instance.postgres_instance will be updated in-place
  ~ resource "cloudfoundry_service_instance" "postgres_instance" {
        id                             = "99d5eb3d-538a-4788-ae17-cd5a11590db1"
        name                           = "ey-recovery-pr-383-db"
      ~ service_plan                   = "397eff33-450a-4a62-9a67-2124255c92e6" -> "4a2761dd-7c9e-4528-b234-423c848cab77"
        tags                           = []
        # (5 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
module.paas.cloudfoundry_service_instance.postgres_instance: Modifying... [id=99d5eb3d-538a-4788-ae17-cd5a11590db1]
╷
│ Error: Service broker error: Invalid to enable extensions and update plan in the same command
│
│   with module.paas.cloudfoundry_service_instance.postgres_instance,
│   on modules/paas/main.tf line 63, in resource "cloudfoundry_service_instance" "postgres_instance":
│   63: resource "cloudfoundry_service_instance" "postgres_instance" {
│
```