### PR TITLE
Update to v3 of the blue-green strategy

### DIFF
--- a/terraform/app/modules/paas/inputs.tf
+++ b/terraform/app/modules/paas/inputs.tf
@@ -76,7 +76,7 @@ variable "web_app_stopped" {
 
 variable "web_app_deployment_strategy" {
   type    = string
-  default = "blue-green-v2"
+  default = "blue-green-v3"
 }
 
 

--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -31,10 +31,10 @@ resource "cloudfoundry_app" "web_app" {
   instances                  = var.web_app_instances     # default: 1
   memory                     = var.web_app_memory        # default: 512
   disk_quota                 = var.web_app_disk_quota    # default: 2GB
+  strategy                   = var.web_app_deployment_strategy
   health_check_type          = "http"
   health_check_http_endpoint = "/health"
   stopped                    = false
-  strategy                   = "blue-green-v2"
   timeout                    = 300
   docker_image               = var.app_docker_image
   space                      = data.cloudfoundry_space.space.id


### PR DESCRIPTION
Deployments blocked by bumped version strategy

https://github.com/DFE-Digital/early-years-foundation-recovery/actions/runs/3523578334/jobs/5908084184#step:8:329

Opting to retain the explicit version number in Terraform