### PR TITLE
ER-538 Add back buttons to training pages

### DIFF
--- a/app/controllers/assessment_results_controller.rb
+++ b/app/controllers/assessment_results_controller.rb
@@ -1,6 +1,7 @@
 class AssessmentResultsController < ApplicationController
   before_action :authenticate_registered_user!, :clear_flash, :show_progress_bar
   after_action :track_events, only: :show
+  helper_method :training_module
 
   def new
     helpers.assessment_progress(training_module).archive_attempt

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -1,6 +1,7 @@
 class QuestionnairesController < ApplicationController
   before_action :authenticate_registered_user!, :module_item, :show_progress_bar
   before_action :track_events, only: :show
+  helper_method :training_module
 
   def show
     questionnaire_taker.prepare

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -104,4 +104,13 @@ module ContentHelper
   def service_name
     Rails.configuration.service_name
   end
+
+  def back_to_module_overview_button
+    if params[:controller].eql?('content_pages')
+      govuk_back_link(
+        href: training_module_path(params[:training_module_id]),
+        text: "Back to Module #{training_module.id} overview",
+      )
+    end
+  end
 end

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -106,7 +106,7 @@ module ContentHelper
   end
 
   def back_to_module_overview_button
-    if params[:controller].eql?('content_pages')
+    if %w[content_pages questionnaires assessment_results].include?(params[:controller])
       govuk_back_link(
         href: training_module_path(params[:training_module_id]),
         text: "Back to Module #{training_module.id} overview",

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -35,6 +35,8 @@ html.govuk-template lang='en'
       = govuk_phase_banner(tag: { text: 'Beta' }, classes: 'noprint') do
         = t('phase_banner_html', feedback_link: govuk_link_to('feedback', Rails.configuration.feedback_url, target: :_blank))
 
+      = back_to_module_overview_button
+
       main#main-content.govuk-main-wrapper
         - flash.each do |variant, message|
           = govuk_notification_banner title_text: t("banners.#{variant}"), text: translate_markdown(message), success: %w[important notice].include?(variant), classes: "govuk-notification-banner--#{variant}"

--- a/spec/system/assessment_results_spec.rb
+++ b/spec/system/assessment_results_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'Assessment results page' do
+  include_context 'with progress'
+  include_context 'with user'
+
+  context 'when on a content page in the first module' do
+    before do
+      visit 'modules/alpha/assessment-result/1-3-2-5'
+    end
+
+    specify do
+      expect(page).to have_link 'Back to Module 1 overview', href: '/modules/alpha'
+    end
+  end
+
+  context 'when on a content page in the second module' do
+    before do
+      visit 'modules/bravo/assessment-result/1-2-2-4'
+    end
+
+    specify do
+      expect(page).to have_link 'Back to Module 2 overview', href: '/modules/bravo'
+    end
+  end
+end

--- a/spec/system/content_page_spec.rb
+++ b/spec/system/content_page_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'Content page' do
+  include_context 'with progress'
+  include_context 'with user'
+
+  context 'when on a content page in the first module' do
+    before do
+      start_first_submodule(alpha)
+      visit 'modules/alpha/content-pages/1-1'
+    end
+
+    specify do
+      expect(page).to have_link 'Back to Module 1 overview', href: '/modules/alpha'
+    end
+  end
+
+  context 'when on a content page in the second module' do
+    before do
+      start_first_submodule(bravo)
+      visit 'modules/bravo/content-pages/1-1'
+    end
+
+    specify do
+      expect(page).to have_link 'Back to Module 2 overview', href: '/modules/bravo'
+    end
+  end
+end

--- a/spec/system/formative_questionnaire_spec.rb
+++ b/spec/system/formative_questionnaire_spec.rb
@@ -44,4 +44,11 @@ RSpec.describe 'Formative questionnaire' do
       expect(page).to have_selector('.govuk-radios__input:disabled')
     end
   end
+
+  context 'when on a questionnaire page' do
+    specify do
+      visit 'modules/alpha/content-pages/1-1'
+      expect(page).to have_link 'Back to Module 1 overview', href: '/modules/alpha'
+    end
+  end
 end

--- a/spec/system/summative_questionnaire_spec.rb
+++ b/spec/system/summative_questionnaire_spec.rb
@@ -152,4 +152,11 @@ RSpec.describe 'Summative questionnaire' do
       expect(page).to have_link 'revisit topic'
     end
   end
+
+  context 'when on a questionnaire page' do
+    specify do
+      visit 'modules/alpha/content-pages/1-1'
+      expect(page).to have_link 'Back to Module 1 overview', href: '/modules/alpha'
+    end
+  end
 end


### PR DESCRIPTION
Ticket: [ER-538](https://dfedigital.atlassian.net/browse/ER-538)

- Add back button to each content page

Screenshot:
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/13471320/208482957-cbc6466f-dd9d-48da-a0eb-0d4755efed71.png">
