### PR TITLE
Account deletion hotfix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :set_analytics_tracking_id, :set_hotjar_site_id
+  before_action :set_analytics_tracking_id, :set_hotjar_site_id, :set_internal_mailbox_email_address
 
   helper_method :timeout_timer
 
@@ -34,6 +34,10 @@ class ApplicationController < ActionController::Base
 
   def set_hotjar_site_id
     @hotjar_id = Rails.configuration.hotjar_site_id
+  end
+
+  def set_internal_mailbox_email_address
+    @internal_mailbox = Rails.configuration.internal_mailbox
   end
 
   def timeout_timer

--- a/app/controllers/close_accounts_controller.rb
+++ b/app/controllers/close_accounts_controller.rb
@@ -23,6 +23,7 @@ class CloseAccountsController < ApplicationController
 
   def close_account
     current_user.send_account_closed_notification
+    User.new(email: @internal_mailbox).send_account_closed_internal_notification(current_user.email)
     current_user.redact!
     sign_out current_user
     redirect_to user_close_account_path

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -31,7 +31,6 @@ class NotifyMailer < GovukNotifyRails::Mailer
     set_template(ACCOUNT_CLOSED_INTERNAL_TEMPLATE_ID)
 
     set_personalisation(
-      name: record.name,
       email: record.email,
       user_email_address: user_email_address,
     )

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,5 +1,6 @@
 class NotifyMailer < GovukNotifyRails::Mailer
   ACCOUNT_CLOSED_TEMPLATE_ID = '0a4754ee-6175-444c-98a1-ebef0b14e7f7'.freeze
+  ACCOUNT_CLOSED_INTERNAL_TEMPLATE_ID = 'a2dba0ef-84f1-4b4d-b50a-ce953050798e'.freeze
   ACTIVATION_TEMPLATE_ID = 'd6ab2e3b-923e-429e-abd2-cfe7be0e9193'.freeze
   EMAIL_CHANGED_TEMPLATE_ID = 'c1228884-6621-4a1e-9606-b219bedb677f'.freeze
   EMAIL_CONFIRMATION_TEMPLATE_ID = 'a2412831-e253-4df4-a8f1-19332eed4cef'.freeze
@@ -23,7 +24,18 @@ class NotifyMailer < GovukNotifyRails::Mailer
       name: record.name,
       email: record.email,
     )
-    mail(to: record.email, bcc: 'child-development.training@education.gov.uk')
+    mail(to: record.email)
+  end
+
+  def account_closed_internal(record, user_email_address)
+    set_template(ACCOUNT_CLOSED_INTERNAL_TEMPLATE_ID)
+
+    set_personalisation(
+      name: record.name,
+      email: record.email,
+      user_email_address: user_email_address,
+    )
+    mail(to: record.email)
   end
 
   def activation_instructions(record, token, _opts = {})

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -88,6 +88,10 @@ class User < ApplicationRecord
     send_devise_notification(:account_closed)
   end
 
+  def send_account_closed_internal_notification(user_account_email)
+    send_devise_notification(:account_closed_internal, user_account_email)
+  end
+
   # @return [String]
   def name
     [first_name, last_name].compact.join(' ')

--- a/app/views/close_accounts/new.html.slim
+++ b/app/views/close_accounts/new.html.slim
@@ -10,7 +10,7 @@
           aria: { required: true },
           label: { text: 'For security, enter your password.'},
           hint: { text: 'Your password' } do 
-          p= govuk_details(summary_text: 'Problems signing in') do
+          p= govuk_details(summary_text: 'Problems with your password?') do
             p.govuk-heading-s= 'I have forgotten my password'
             = "If you have forgotten your password you can "
             = govuk_link_to 'reset it', reset_password_user_close_account_path

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,7 @@ module EarlyYearsFoundationRecovery
     # user_timeout_warning_minutes and user_timeout_modal_visible value combined must be lower than user_timeout_minutes
     config.user_timeout_warning_minutes = ENV.fetch('TIMEOUT_WARNING_MINUTES', '20').to_i
     config.user_timeout_modal_visible = ENV.fetch('TIMEOUT_MODAL_VISIBLE', '5').to_i
+    config.internal_mailbox = ENV.fetch('INTERNAL_MAILBOX', 'child-development.training@education.gov.uk')
     config.service_name = 'Early years child development training'
     config.middleware.use Grover::Middleware
     config.active_record.yaml_column_permitted_classes = [Symbol]

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe NotifyMailer, type: :mailer do
   let(:user) { create(:user) }
+  let(:mailbox) { User.new(email: 'child-development.training@education.gov.uk') }
 
   describe 'email confirmation / account activation' do
     context 'when signing up' do
@@ -77,8 +78,12 @@ RSpec.describe NotifyMailer, type: :mailer do
       it 'send email to user to confirm account has been closed' do
         mail = described_class.account_closed(user)
         expect(mail.to).to contain_exactly(user.email)
-        expect(mail.bcc).to contain_exactly('child-development.training@education.gov.uk')
         expect(mail.subject).to eq 'Account closed'
+      end
+
+      it 'send email to internal mailbox' do
+        mail = described_class.account_closed_internal(mailbox, user)
+        expect(mail.to).to contain_exactly(mailbox.email)
       end
     end
   end


### PR DESCRIPTION
- update wording
- replace bcc in email with separate internal email listing accounts that have been deleted