### PR TITLE
Remove deleted pages from sitemap

### DIFF
--- a/app/decorators/module_progress_bar_decorator.rb
+++ b/app/decorators/module_progress_bar_decorator.rb
@@ -1,11 +1,3 @@
-#
-# Progress nodes are started when:
-#   - interruption page in intro node is viewed
-#   - first content page in submodule node is viewed
-#   - recap page in module summary node is viewed
-#
-# Headings are bold when page is within section
-#
 class ModuleProgressBarDecorator < DelegateClass(ModuleProgress)
   # @return [Array<Hash{Symbol => String,Boolean,Hash}>]
   def nodes

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -95,8 +95,6 @@ SitemapGenerator::Sitemap.create do
 
   # Representative content
   add training_module_content_page_path(mod, mod.interruption_page)
-  add training_module_content_page_path(mod, mod.icons_page)
-  add training_module_content_page_path(mod, mod.intro_page)
   add training_module_content_page_path(mod, mod.first_content_page)
   add training_module_content_page_path(mod, mod.video_pages.first)
   add training_module_content_page_path(mod, mod.formative_questions.first)


### PR DESCRIPTION
When `sitemap:refresh:no_ping` is run (part of the `paas_web_app_start_command` for development apps) it was failing due to the pages that had been removed. 

Fix for https://early-years-foundation-reform.sentry.io/issues/3920070448

From this workflow: https://github.com/DFE-Digital/early-years-foundation-recovery/actions/runs/4105734668

[ER-610](https://dfedigital.atlassian.net/browse/ER-610)

[ER-610]: https://dfedigital.atlassian.net/browse/ER-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ