### PR TITLE
Mimic CMS workflow using dev/staging

### DIFF
--- a/terraform/workspace-variables/app_config.yml
+++ b/terraform/workspace-variables/app_config.yml
@@ -27,6 +27,8 @@ staging:
   DOMAIN: ey-recovery-staging.london.cloudapps.digital
   GOVUK_WEBSITE_ROOT: ey-recovery-staging
   TRACKING_ID: GTM-W6W95FD  # Test data
+  CONTENTFUL: true
+  CONTENTFUL_ENVIRONMENT: genuine-with-5 # Defaults to "master" without override
 
 # ey-recovery-dev
 development:
@@ -34,14 +36,14 @@ development:
   DOMAIN: ey-recovery-dev.london.cloudapps.digital
   GOVUK_WEBSITE_ROOT: ey-recovery-dev
   CONTENTFUL: true
-  CONTENTFUL_ENVIRONMENT: test
+  CONTENTFUL_ENVIRONMENT: genuine-with-5 # Override would be "test/demo" normally
 
 # ey-recovery-content
 content:
   <<: *defaults
   CONTENTFUL: true
-  CONTENTFUL_ENVIRONMENT: genuine
-  TRAINING_MODULES: demo-modules
+  CONTENTFUL_ENVIRONMENT: genuine-with-5
+  # TRAINING_MODULES: demo-modules
   # @see .github/workflows/content.yml
   # DOMAIN: xxx.london.cloudapps.digital
   # GOVUK_WEBSITE_ROOT: xxx


### PR DESCRIPTION
Enables CMS preview testing using integration environment in place of production

Requires a release candidate deployed to staging in order to start testing.