### PR TITLE
CMS testing on staging

### DIFF
--- a/app/controllers/contentful/base_controller.rb
+++ b/app/controllers/contentful/base_controller.rb
@@ -1,5 +1,5 @@
 class Contentful::BaseController < ApplicationController
-  before_action do
-    ContentfulModel.use_preview_api = Rails.application.preview?
-  end
+  # before_action do
+  #   ContentfulRails.configuration.enable_preview_domain = Rails.application.preview?
+  # end
 end

--- a/app/models/training/content.rb
+++ b/app/models/training/content.rb
@@ -2,6 +2,11 @@ module Training
   class Content < ContentfulModel::Base
     extend Dry::Core::Cache
 
+    # @return [Boolean]
+    def self.cache?
+      Rails.env.test?
+    end
+
     # METHODS TO DEPRECATE --------------------------------------
 
     # @return [self]
@@ -21,11 +26,9 @@ module Training
 
     # METHODS TO DEPRECATE --------------------------------------
 
+    # NB: do not apply additional caching here
     # @return [Training::Content]
     def self.by_id(id)
-      # return load_children(0).find(id) if Rails.application.live?
-      # fetch_or_store(id) { load_children(0).find(id) }
-
       load_children(0).find(id)
     end
 

--- a/app/models/training/content.rb
+++ b/app/models/training/content.rb
@@ -23,6 +23,9 @@ module Training
 
     # @return [Training::Content]
     def self.by_id(id)
+      # return load_children(0).find(id) if Rails.application.live?
+      # fetch_or_store(id) { load_children(0).find(id) }
+
       load_children(0).find(id)
     end
 

--- a/app/models/training/module.rb
+++ b/app/models/training/module.rb
@@ -16,7 +16,7 @@ module Training
 
     # @return [Array<Training::Module>]
     def self.ordered
-      return load_children(0).order(:position).load!.to_a if Rails.application.live?
+      return load_children(0).order(:position).load!.to_a unless cache?
 
       fetch_or_store(__method__) do
         load_children(0).order(:position).load!.to_a
@@ -34,7 +34,7 @@ module Training
 
     # @return [Training::Module] cached result
     def self.by_id(id)
-      return load_children(0).find(id) if Rails.application.live?
+      return load_children(0).find(id) unless cache?
 
       fetch_or_store(id) do
         load_children(0).find(id)
@@ -43,7 +43,7 @@ module Training
 
     # @return [Training::Module] cached result
     def self.by_name(name)
-      return load_children(0).find_by(name: name.to_s).first if Rails.application.live?
+      return load_children(0).find_by(name: name.to_s).first unless cache?
 
       fetch_or_store(name.to_s) do
         load_children(0).find_by(name: name.to_s).first
@@ -58,7 +58,7 @@ module Training
     # @return [String, nil] cached result
     def thumbnail_url
       return '//external-image-resource-placeholder' if fields[:image].blank?
-      return ContentfulModel::Asset.find(fields[:image].id).url if Rails.application.live?
+      return ContentfulModel::Asset.find(fields[:image].id).url unless self.class.cache?
 
       fetch_or_store(fields[:image].id) do
         ContentfulModel::Asset.find(fields[:image].id).url
@@ -70,18 +70,29 @@ module Training
       self.class.by_id(fields[:depends_on].id) if fields[:depends_on]
     end
 
-    # source of truth for content order
+    # Most expensive method: source of truth for content order
     #
     # @return [Array<Training::Page, Training::Video, Training::Question>] cached result
     def content
       return [] if draft?
 
-      fields[:pages].map do |child_link|
-        if Rails.application.live?
-          child_by_id(child_link.id)
-        else
+      # fields[:pages].map do |child_link|
+      #   if self.class.cache?
+      #     fetch_or_store(child_link.id) { child_by_id(child_link.id) }
+      #   else
+      #     child_by_id(child_link.id)
+      #   end
+      # end
+
+      if self.class.cache? # RAILS_ENV=test
+        fields[:pages].map do |child_link|
           fetch_or_store(child_link.id) { child_by_id(child_link.id) }
         end
+      else
+        # @content ||=
+          fields[:pages].map do |child_link|
+            child_by_id(child_link.id)
+          end
       end
     end
 
@@ -136,7 +147,7 @@ module Training
     #
     # @return [Boolean]
     def draft?
-      fields.fetch(:pages, []).none?
+      fields.fetch(:pages, []).none? # || ContentIntegrityCheck
     end
 
     # # @return [Datetime]

--- a/app/models/training/module.rb
+++ b/app/models/training/module.rb
@@ -76,21 +76,10 @@ module Training
     def content
       return [] if draft?
 
-      # fields[:pages].map do |child_link|
-      #   if self.class.cache?
-      #     fetch_or_store(child_link.id) { child_by_id(child_link.id) }
-      #   else
-      #     child_by_id(child_link.id)
-      #   end
-      # end
-
-      if self.class.cache? # RAILS_ENV=test
-        fields[:pages].map do |child_link|
+      fields[:pages].map do |child_link|
+        if self.class.cache?
           fetch_or_store(child_link.id) { child_by_id(child_link.id) }
-        end
-      else
-        # @content ||=
-        fields[:pages].map do |child_link|
+        else
           child_by_id(child_link.id)
         end
       end

--- a/app/models/training/module.rb
+++ b/app/models/training/module.rb
@@ -90,9 +90,9 @@ module Training
         end
       else
         # @content ||=
-          fields[:pages].map do |child_link|
-            child_by_id(child_link.id)
-          end
+        fields[:pages].map do |child_link|
+          child_by_id(child_link.id)
+        end
       end
     end
 

--- a/app/models/training/module.rb
+++ b/app/models/training/module.rb
@@ -16,7 +16,11 @@ module Training
 
     # @return [Array<Training::Module>]
     def self.ordered
-      load_children(0).order(:position).load!.to_a
+      return load_children(0).order(:position).load!.to_a if Rails.application.live?
+
+      fetch_or_store(__method__) do
+        load_children(0).order(:position).load!.to_a
+      end
     end
 
     # cached queries ---------------------------------
@@ -30,6 +34,8 @@ module Training
 
     # @return [Training::Module] cached result
     def self.by_id(id)
+      return load_children(0).find(id) if Rails.application.live?
+
       fetch_or_store(id) do
         load_children(0).find(id)
       end
@@ -37,6 +43,8 @@ module Training
 
     # @return [Training::Module] cached result
     def self.by_name(name)
+      return load_children(0).find_by(name: name.to_s).first if Rails.application.live?
+
       fetch_or_store(name.to_s) do
         load_children(0).find_by(name: name.to_s).first
       end
@@ -50,6 +58,7 @@ module Training
     # @return [String, nil] cached result
     def thumbnail_url
       return '//external-image-resource-placeholder' if fields[:image].blank?
+      return ContentfulModel::Asset.find(fields[:image].id).url if Rails.application.live?
 
       fetch_or_store(fields[:image].id) do
         ContentfulModel::Asset.find(fields[:image].id).url
@@ -68,7 +77,11 @@ module Training
       return [] if draft?
 
       fields[:pages].map do |child_link|
-        fetch_or_store(child_link.id) { child_by_id(child_link.id) }
+        if Rails.application.live?
+          child_by_id(child_link.id)
+        else
+          fetch_or_store(child_link.id) { child_by_id(child_link.id) }
+        end
       end
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -74,12 +74,12 @@ module EarlyYearsFoundationRecovery
 
     # @return [Boolean] true if Contentful is used for training content
     def cms?
-      ENV['CONTENTFUL'].present?
+      Types::Params::Bool[ENV.fetch('CONTENTFUL', true)]
     end
 
     # @return [Boolean] Upload to CSV files to the dashboard
     def dashboard?
-      ENV['DASHBOARD_UPDATE'].present? || live?
+      Types::Params::Bool[ENV.fetch('DASHBOARD_UPDATE', true)]
     end
 
     # @see Training::BaseController

--- a/config/initializers/contentful_rails.rb
+++ b/config/initializers/contentful_rails.rb
@@ -8,7 +8,7 @@ require 'contentful/static'
 ContentfulRails.configure do |config|
   config.space            = Rails.application.config.contentful_space
   config.environment      = Rails.application.config.contentful_environment
-  config.perform_caching  = Rails.application.live?
+  config.perform_caching  = Rails.env.production?
   config.default_locale   = 'en-US' # Optional - defaults to 'en-US'
 
   # Webhooks
@@ -28,8 +28,17 @@ ContentfulRails.configure do |config|
   config.eager_load_entry_mapping = false
 
   config.contentful_options = {
+    logger: (Rails.logger if Rails.env.development?),
+
+    # Prevent recursion
+    max_include_resolution_depth: 1,
+    reuse_entries: true,
+
+    # Timeout settings
+    preview_api: { timeout_connect: 2, timeout_read: 6, timeout_write: 20 },
     delivery_api: { timeout_connect: 2, timeout_read: 6, timeout_write: 20 },
     management_api: { timeout_connect: 3, timeout_read: 100, timeout_write: 200 },
+
     entry_mapping: {
       'static' => Contentful::Static,
       'trainingModule' => Training::Module,

--- a/config/initializers/contentful_rails.rb
+++ b/config/initializers/contentful_rails.rb
@@ -9,15 +9,15 @@ ContentfulRails.configure do |config|
   config.space            = Rails.application.config.contentful_space
   config.environment      = Rails.application.config.contentful_environment
   config.perform_caching  = Rails.env.production?
-  config.default_locale   = 'en-US' # Optional - defaults to 'en-US'
+  config.default_locale   = 'en-US'
 
   # Webhooks
-  # config.authenticate_webhooks = true # false here would allow the webhooks to process without basic auth
-  # config.webhooks_username = 'ey_recovery'
-  # config.webhooks_password = 'ey_recovery'
+  config.authenticate_webhooks = true
+  config.webhooks_username = 'ey_recovery'
+  config.webhooks_password = 'ey_recovery'
 
-  # Preview is enabled for local development and staging
-  # config.enable_preview_domain =
+  # Preview enabled for local development and staging
+  config.enable_preview_domain = Rails.application.preview?
   # config.preview_domain =
 
   # Tokens

--- a/config/initializers/contentful_rails.rb
+++ b/config/initializers/contentful_rails.rb
@@ -28,7 +28,7 @@ ContentfulRails.configure do |config|
   config.eager_load_entry_mapping = false
 
   config.contentful_options = {
-    logger: (Rails.logger if Rails.env.development?),
+    logger: Rails.logger,
 
     # Prevent recursion
     max_include_resolution_depth: 1,

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,6 +11,7 @@ services:
       - DOMAIN=recovery.app
       - TRAINING_MODULES=demo-modules
       - BOT_TOKEN=bot_token
+      - CONTENTFUL_ENVIRONMENT=test
     tty: true
     stdin_open: true
 

--- a/terraform/workspace-variables/app_config.yml
+++ b/terraform/workspace-variables/app_config.yml
@@ -13,6 +13,7 @@ defaults: &defaults
   GOVUK_APP_DOMAIN: london.cloudapps.digital
   GROVER_NO_SANDBOX: true
   EDITOR: vi
+  CONTENTFUL_ENVIRONMENT: staging # master unless overridden
 
 # ey-recovery
 production:
@@ -23,6 +24,7 @@ production:
   TRACKING_ID: GTM-NFZ88TP  # Live data
   HOTJAR_SITE_ID: 3169682
   GOOGLE_CLOUD_BUCKET: eyfs-data-dashboard-live
+  CONTENTFUL: false
 
 # ey-recovery-staging
 staging:
@@ -32,9 +34,6 @@ staging:
   GOVUK_WEBSITE_ROOT: ey-recovery-staging
   TRACKING_ID: GTM-W6W95FD  # Test data
   GOOGLE_CLOUD_BUCKET: eyfs-data-dashboard-staging
-  DASHBOARD_UPDATE: true # Daily at noon
-  CONTENTFUL: true
-  CONTENTFUL_ENVIRONMENT: genuine-with-5 # Defaults to "master" without override
 
 # ey-recovery-dev
 development:
@@ -43,16 +42,12 @@ development:
   GOVUK_WEBSITE_ROOT: ey-recovery-dev
   TRAINING_MODULES: demo-modules
   GOOGLE_CLOUD_BUCKET: eyfs-data-dashboard-development
-  DASHBOARD_UPDATE: true
-  DASHBOARD_UPDATE_INTERVAL: '*/5 * * * *' # Every 5 mins
-  CONTENTFUL: true
-  CONTENTFUL_ENVIRONMENT: genuine-with-5 # Override would be "test/demo" normally
+  DASHBOARD_UPDATE_INTERVAL: '*/5 * * * *' # every 5 mins (default: daily at noon)
 
 # ey-recovery-content
 content:
   <<: *defaults
-  CONTENTFUL: true
-  CONTENTFUL_ENVIRONMENT: genuine-with-5
+  DASHBOARD_UPDATE: false
   # TRAINING_MODULES: demo-modules
   # @see .github/workflows/content.yml
   # DOMAIN: xxx.london.cloudapps.digital


### PR DESCRIPTION
- enable CMS by default (still disabled on production)
- point to the `staging` alias by default (which is currently populated with the `production` environment content)
- disable additional caching except for test runs (slower page loads in production until webhooks are implemented)