### PR TITLE
Fixed typo on 1-1-2-6

### DIFF
--- a/config/locales/modules/child-development-and-the-eyfs.yml
+++ b/config/locales/modules/child-development-and-the-eyfs.yml
@@ -509,7 +509,7 @@ en:
 
           ##Negative impact
 
-          Some children may have had restricted access or opportunity for physical activity and outdoor space. This may have resulted in reduced movement. Children who have been able to take extended naps and periods of rest may now lack the stamina needed to complete a day in a chilcare setting.
+          Some children may have had restricted access or opportunity for physical activity and outdoor space. This may have resulted in reduced movement. Children who have been able to take extended naps and periods of rest may now lack the stamina needed to complete a day in a childcare setting.
 
           Where parents and carers have worked from home, children may have spent more time watching TV or playing on tablets or games consoles to maintain their interest. This will have resulted in prolonged periods of inactivity.
 


### PR DESCRIPTION
"chilcare" corrected to "childcare" in: "Some children may have had restricted access or opportunity for physical activity and outdoor space. This may have resulted in reduced movement. Children who have been able to take extended naps and periods of rest may now lack the stamina needed to complete a day in a childcare setting."