### PR TITLE
Fixes and tests

### DIFF
--- a/.github/workflows/cms.yml
+++ b/.github/workflows/cms.yml
@@ -6,19 +6,19 @@ on:
   workflow_dispatch:
     inputs:
       alias:
-        description: Contentful alias to target (master)
+        description: Contentful alias to target (master, staging, test)
         type: string
-        default: staging # master
+        default: master
 
 jobs:
   test:
-    name: Preflight
+    name: Content 2i
     runs-on: ubuntu-latest
     environment: test
     env:
-      CONTENTFUL_ENVIRONMENT: ${{ inputs.alias }})
-      # https://github.com/DFE-Digital/early-years-foundation-recovery/settings/secrets/dependabot
+      RAILS_ENV: test
       RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+      CONTENTFUL_ENVIRONMENT: ${{ inputs.alias }}
 
     steps:
       -
@@ -34,10 +34,10 @@ jobs:
         name: Install Rubygems
         run: bundle install --jobs 20 --retry 3
       -
-        name: Validate draft
-        run: bundle exec rails eyfs:cms:validate
+        name: Validate draft (pre-release)
         env:
-          CONTENTFUL_PREVIEW: true
+          CONTENTFUL_PREVIEW: 'on'
+        run: bundle exec rails eyfs:cms:validate
       -
-        name: Validate published
+        name: Validate published (post-release)
         run: bundle exec rails eyfs:cms:validate

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -3,7 +3,13 @@ module ContentHelper
   # @param markdown [String]
   # @return [String]
   def translate_markdown(markdown)
-    raw Govspeak::Document.to_html(markdown, sanitize: false)
+    if markdown.is_a?(String)
+      raw Govspeak::Document.to_html(markdown, sanitize: false)
+    else
+      message = 'DEBUGGING: flash message was not a string'
+      Sentry.capture_message(message)
+      message
+    end
   end
 
   # Date format guidelines: "1 June 2002"

--- a/config/application.rb
+++ b/config/application.rb
@@ -98,7 +98,7 @@ module EarlyYearsFoundationRecovery
 
     # @return [Boolean]
     def debug?
-      Rails.env.development? || ENV['WORKSPACE'].eql?('content')
+      Rails.env.development? || ENV['WORKSPACE'].eql?('content') || cms?
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -82,12 +82,15 @@ module EarlyYearsFoundationRecovery
       Types::Params::Bool[ENV.fetch('DASHBOARD_UPDATE', true)]
     end
 
+    # CI workflow uses DELIVERY
+    # CMS workflow uses PREVIEW then DELIVERY
+    #
     # @see ContentfulRails.configuration.enable_preview_domain
     # @see ContentfulModel.use_preview_api
     #
     # @return [Boolean]
     def preview?
-      if Rails.env.test?
+      if Rails.env.test? && ENV['CONTENTFUL_PREVIEW'].blank?
         false
       elsif Rails.env.development? || ENV['WORKSPACE'].eql?('staging') || ENV['CONTENTFUL_PREVIEW'].present?
         true

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -58,7 +58,7 @@ end
 
 lowlevel_error_handler do |error|
   Sentry.capture_message(error.message)
-  FileUtils.touch Rails.root.join('tmp/restart.txt')
+  # FileUtils.touch Rails.root.join('tmp/restart.txt')
 
-  [500, {}, ["Contact #{Rails.application.config.internal_mailbox} for support\n"]]
+  # [500, {}, ["Contact #{Rails.application.config.internal_mailbox} for support\n"]]
 end

--- a/terraform/workspace-variables/app_config.yml
+++ b/terraform/workspace-variables/app_config.yml
@@ -50,7 +50,7 @@ content:
   <<: *defaults
   DASHBOARD_UPDATE: false
   CONTENTFUL_PREVIEW: true
-  CONTENTFUL_ENVIRONMENT: test
+  # CONTENTFUL_ENVIRONMENT: test
   # @see .github/workflows/content.yml
   # DOMAIN: xxx.london.cloudapps.digital
   # GOVUK_WEBSITE_ROOT: xxx


### PR DESCRIPTION
- review app using staging preview
- CMS content triage using GH workflow
- new noisy Devise flash error debugging
- no forced restart for low-level puma errors
- temporarily enable debugging if CMS feature is enabled (all deployments not just review apps)