### PR TITLE
ER-668: Snags

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -24,7 +24,7 @@ on:
       - completed
 
 env:
-  BASE_URL: ey-recovery-${{ inputs.workspace || 'dev' }}.london.cloudapps.digital
+  BASE_URL: https://ey-recovery-${{ inputs.workspace || 'dev' }}.london.cloudapps.digital
   USER_PASSWORD: ${{ secrets.USER_PASSWORD }}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![ci][ci-badge]][ci-workflow]
 [![brakeman][brakeman-badge]][brakeman-workflow]
 [![pa11y][pa11y-badge]][pa11y-workflow]
+[![qa][qa-badge]][qa-workflow]
 
 This is a Rails 7 application using the [DfE template][rails-template].
 
@@ -419,9 +420,11 @@ settings the following classes can be added:
 [ci-workflow]: https://github.com/DFE-Digital/early-years-foundation-recovery/actions/workflows/ci.yml
 [production-workflow]: https://github.com/DFE-Digital/early-years-foundation-recovery/actions/workflows/production.yml
 [staging-workflow]: https://github.com/DFE-Digital/early-years-foundation-recovery/actions/workflows/staging.yml
+[qa-workflow]: https://github.com/DFE-Digital/early-years-foundation-recovery/actions/workflows/qa.yml
 
 <!-- GH workflow badges -->
 
 [brakeman-badge]: https://github.com/DFE-Digital/early-years-foundation-recovery/actions/workflows/brakeman.yml/badge.svg
 [pa11y-badge]: https://github.com/DFE-Digital/early-years-foundation-recovery/actions/workflows/pa11y.yml/badge.svg
 [ci-badge]: https://github.com/DFE-Digital/early-years-foundation-recovery/actions/workflows/ci.yml/badge.svg
+[qa-badge]: https://github.com/DFE-Digital/early-years-foundation-recovery/actions/workflows/qa.yml/badge.svg

--- a/app/controllers/training/modules_controller.rb
+++ b/app/controllers/training/modules_controller.rb
@@ -25,7 +25,21 @@ protected
 
   # @return [Boolean]
   def redirect?
-    mod.nil? || (!Rails.application.preview? && mod.draft?) || (Rails.application.preview? && !mod.pages?)
+    mod.nil? || unreleased? || wip?
+  end
+
+  # When authoring a new module the overview page will not be accessible until
+  # the module has some content. This will generate an application error unless
+  # the module content passes the data integrity check.
+  #
+  # @return [Boolean]
+  def wip?
+    Rails.application.preview? && !mod.pages?
+  end
+
+  # @return [Boolean]
+  def unreleased?
+    !Rails.application.preview? && mod.draft?
   end
 
   # @return [Boolean]

--- a/app/models/training/content.rb
+++ b/app/models/training/content.rb
@@ -23,7 +23,7 @@ module Training
     def published_at
       return unless Rails.env.development? && ENV['CONTENTFUL_MANAGEMENT_TOKEN'].present?
 
-      entry.published_at.in_time_zone(ENV['TZ']).strftime('%d-%m-%Y %H:%M')
+      entry.published_at&.in_time_zone(ENV['TZ'])&.strftime('%d-%m-%Y %H:%M')
     end
 
     # @see Training::Content#debug_summary

--- a/app/models/training/module.rb
+++ b/app/models/training/module.rb
@@ -147,7 +147,7 @@ module Training
     def published_at
       return unless Rails.env.development? && ENV['CONTENTFUL_MANAGEMENT_TOKEN'].present?
 
-      entry.published_at.in_time_zone(ENV['TZ']).strftime('%d-%m-%Y %H:%M')
+      entry.published_at&.in_time_zone(ENV['TZ'])&.strftime('%d-%m-%Y %H:%M')
     end
 
     # @see Training::Module#debug_summary

--- a/app/services/contentful_data_integrity.rb
+++ b/app/services/contentful_data_integrity.rb
@@ -3,7 +3,7 @@
 class ContentfulDataIntegrity
   extend Dry::Initializer
 
-  option :module_name, Types::String.enum(*Training::Module.ordered.map(&:name))
+  option :module_name, Types::String
 
   # NB: Able to be validated in the CMS editor
   #

--- a/app/views/training/questions/show.html.slim
+++ b/app/views/training/questions/show.html.slim
@@ -19,4 +19,5 @@
         - if content.confidence_question? || !current_user_response.responded?
           = f.govuk_submit content.next_button_text
         - else
+          = f.govuk_submit 'Responded', class: 'govuk-visually-hidden', disabled: true
           = cms_link_to_next_module_item(content)

--- a/spec/cms/services/contentful_data_integrity_spec.rb
+++ b/spec/cms/services/contentful_data_integrity_spec.rb
@@ -9,14 +9,6 @@ RSpec.describe ContentfulDataIntegrity, :cms do
     skip 'WIP' unless Rails.application.cms?
   end
 
-  context 'when module is not found' do
-    let(:mod) { 'foo' }
-
-    it 'raises constraint error' do
-      expect { service }.to raise_error Dry::Types::ConstraintError
-    end
-  end
-
   context 'when module is not specified' do
     let(:mod) { nil }
 
@@ -29,19 +21,25 @@ RSpec.describe ContentfulDataIntegrity, :cms do
     context 'when valid' do
       let(:mod) { 'alpha' }
 
-      specify { expect(service.valid?).to be true }
+      specify { expect(service).to be_valid }
     end
 
     context 'when invalid' do
       let(:mod) { 'delta' }
 
-      specify { expect(service.valid?).to be false } # something should be missing e.g. duration
+      specify { expect(service).not_to be_valid } # something should be missing e.g. duration
     end
   end
 
   describe '#consecutive_integers?' do
     let(:mod) { 'charlie' }
     let(:output) { service.consecutive_integers?(input) }
+
+    context 'when input is empty' do
+      let(:input) { [] }
+
+      specify { expect(output).to be false }
+    end
 
     context 'when not consecutive' do
       let(:input) { [0, 1, 2, 3, 4, 6] }


### PR DESCRIPTION
- add protocol back to the QA workflow
- add a QA badge to the README
- improve docs for content creation workflow
- defend against unpublished entries when debugging
- satisfy accessibility ensuring forms always have a submit button, disabled where appropriate

Run `./bin/docker-pa11y https://ey-recovery-pr-625.london.cloudapps.digital` where the bot user has already answered https://ey-recovery-pr-625.london.cloudapps.digital/modules/child-development-and-the-eyfs/questionnaires/1-1-1-1b