### PR TITLE
CMS snags

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -92,8 +92,13 @@ module LinkHelper
   # @param content [Module::Content]
   # @return [String] next content page (ends on certificate)
   def cms_link_to_next_module_item(content)
-    text = content.next_button_text
-    path = training_module_page_path(content.parent.name, content.next_item.name)
+    if content.next_item.nil? && Rails.application.preview?
+      text = 'Next page has not been created'
+      path = training_module_page_path(content.parent.name, content.name)
+    else
+      text = content.next_button_text
+      path = training_module_page_path(content.parent.name, content.next_item.name)
+    end
 
     govuk_button_link_to text, path, id: 'next-action', aria: { label: 'Go to the next page' }
   end

--- a/app/models/training/content.rb
+++ b/app/models/training/content.rb
@@ -71,9 +71,9 @@ module Training
     end
 
     # private
-    # @return [String] Contentful Link ID
+    # @return [String, nil] Contentful Link ID
     def next_item_id
-      parent.fields[:pages][position_within_module + 1].id
+      parent.fields[:pages][position_within_module + 1]&.id
     end
 
     # Can be found without loading all content

--- a/app/models/training/question.rb
+++ b/app/models/training/question.rb
@@ -5,22 +5,13 @@ module Training
       'question'
     end
 
-    # @return [Array<Array>]
-    CONFIDENCE_OPTIONS = [
-      ['Strongly agree', true],
-      ['Agree', true],
-      ['Neither agree nor disagree', true],
-      ['Disagree', true],
-      ['Strongly disagree', true],
-    ].freeze
-
     # @see Answer
     delegate :options, :correct_answers, to: :answer
 
-    # @raise [Dry::Struct::Error] if JSON is invalid
+    # @raise [Dry::Struct::Error]
     # @return [Training::Answer]
     def answer
-      @answer ||= Answer.new(json: confidence_question? ? CONFIDENCE_OPTIONS : fields[:answers])
+      @answer ||= Answer.new(json: json)
     end
 
     # @return [Hash{Symbol => nil, Integer}]
@@ -111,6 +102,31 @@ module Training
       else
         'Next'
       end
+    end
+
+  private
+
+    # @return [Array<Array>]
+    CONFIDENCE_OPTIONS = [
+      ['Strongly agree', true],
+      ['Agree', true],
+      ['Neither agree nor disagree', true],
+      ['Disagree', true],
+      ['Strongly disagree', true],
+    ].freeze
+
+    # @note Default values are not available to Contentful JSON fields
+    # @return [Array<Array>]
+    DRAFT_OPTIONS = [
+      ['Wrong answer'],
+      ['Correct answer', true],
+    ].freeze
+
+    # @return [Array<Array>]
+    def json
+      return CONFIDENCE_OPTIONS if confidence_question?
+
+      fields[:answers] || DRAFT_OPTIONS
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,7 +140,6 @@ class User < ApplicationRecord
 
       # module exclusive to CMS
       rescue ActiveHash::RecordNotFound
-
         user_answers.find_or_initialize_by(
           assessments_type: content.assessments_type,
           module: content.parent.name,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,16 +126,30 @@ class User < ApplicationRecord
         archived: false,
       )
     else
-      questionnaire = Questionnaire.find_by!(name: content.name, training_module: content.parent.name)
+      begin
+        questionnaire = Questionnaire.find_by!(name: content.name, training_module: content.parent.name)
 
-      user_answers.find_or_initialize_by(
-        assessments_type: content.assessments_type,
-        module: content.parent.name,
-        name: content.name,
-        questionnaire_id: questionnaire.id,
-        question: questionnaire.questions.keys.first,
-        archived: nil,
-      )
+        user_answers.find_or_initialize_by(
+          assessments_type: content.assessments_type,
+          module: content.parent.name,
+          name: content.name,
+          questionnaire_id: questionnaire.id,
+          question: questionnaire.questions.keys.first,
+          archived: nil,
+        )
+
+      # module exclusive to CMS
+      rescue ActiveHash::RecordNotFound
+
+        user_answers.find_or_initialize_by(
+          assessments_type: content.assessments_type,
+          module: content.parent.name,
+          name: content.name,
+          questionnaire_id: 0,
+          question: 'N/A for CMS only questions',
+          archived: nil,
+        )
+      end
     end
   end
 

--- a/app/services/contentful_data_integrity.rb
+++ b/app/services/contentful_data_integrity.rb
@@ -17,7 +17,7 @@ class ContentfulDataIntegrity
     position: 'Missing position',
     summary: 'Missing short description',
     threshold: 'Missing assessment threshold percentage',
-    # thumbnail: 'Missing thumbnail image',
+    thumbnail: 'Missing thumbnail image',
   }.freeze
 
   # @return [Hash{Symbol=>String}] valid as released module
@@ -88,13 +88,13 @@ class ContentfulDataIntegrity
 
   # MODULE VALIDATIONS ---------------------------------------------------------
 
-  # # @note The asset could be deleted or unpublished.
-  # # @return [Boolean]
-  # def thumbnail?
-  #   mod.fields[:image].present?
-  #   # Unreliable response times prevent this additional check:
-  #   # && ContentfulModel::Asset.find(mod.fields[:image].id).present?
-  # end
+  # @note The asset could be deleted or unpublished.
+  # @return [Boolean]
+  def thumbnail?
+    mod.fields[:image].present?
+    # Unreliable response times prevent this additional check:
+    # && ContentfulModel::Asset.find(mod.fields[:image].id).present?
+  end
 
   # @return [Boolean]
   def description?

--- a/cms/migrate/01-create-page.js
+++ b/cms/migrate/01-create-page.js
@@ -92,13 +92,19 @@ module.exports = function(migration) {
   page.createField('heading', {
     name: 'Heading',
     type: 'Text',
-    required: true
+    required: true,
+    defaultValue: {
+      'en-US': 'page heading',
+    },
   })
 
   page.createField('body', {
     name: 'Body',
     type: 'Text',
-    required: true
+    required: true,
+    defaultValue: {
+      'en-US': 'page body',
+    },
   })
 
   page.createField('notes', {
@@ -111,6 +117,8 @@ module.exports = function(migration) {
   })
 
   /* Interface -------------------------------------------------------------- */
+
+  page.changeFieldControl('heading', 'builtin', 'multipleLine')
 
   page.changeFieldControl('notes', 'builtin', 'boolean', {
     helpText: 'Use Learning Log to take notes?',

--- a/cms/migrate/01-create-page.js
+++ b/cms/migrate/01-create-page.js
@@ -15,7 +15,7 @@ module.exports = function(migration) {
     required: true,
     validations: [
       {
-        prohibitRegexp: { pattern: '\.|\s|[A-Z]' }
+        prohibitRegexp: { pattern: '\\.|\\s|[A-Z]' }
       }
     ]
   })

--- a/cms/migrate/01-create-page.js
+++ b/cms/migrate/01-create-page.js
@@ -12,7 +12,12 @@ module.exports = function(migration) {
   page.createField('name', {
     name: 'Name',
     type: 'Symbol',
-    required: true
+    required: true,
+    validations: [
+      {
+        prohibitRegexp: { pattern: '\.|\s|[A-Z]' }
+      }
+    ]
   })
 
   // type

--- a/cms/migrate/02-create-question.js
+++ b/cms/migrate/02-create-question.js
@@ -120,6 +120,10 @@ module.exports = function(migration) {
 
   /* Interface -------------------------------------------------------------- */
 
+  question.changeFieldControl('body', 'builtin', 'multipleLine')
+  question.changeFieldControl('success_message', 'builtin', 'multipleLine')
+  question.changeFieldControl('failure_message', 'builtin', 'multipleLine')
+
   question.changeFieldControl('answers', 'builtin', 'objectEditor', {
     helpText: 'An array of arrays: add true for correct options',
   })

--- a/cms/migrate/02-create-question.js
+++ b/cms/migrate/02-create-question.js
@@ -15,7 +15,7 @@ module.exports = function(migration) {
     required: true,
     validations: [
       {
-        prohibitRegexp: { pattern: '\.|\s|[A-Z]' }
+        prohibitRegexp: { pattern: '\\.|\\s|[A-Z]' }
       }
     ]
   })

--- a/cms/migrate/02-create-question.js
+++ b/cms/migrate/02-create-question.js
@@ -12,7 +12,12 @@ module.exports = function(migration) {
   question.createField('name', {
     name: 'Name',
     type: 'Symbol',
-    required: true
+    required: true,
+    validations: [
+      {
+        prohibitRegexp: { pattern: '\.|\s|[A-Z]' }
+      }
+    ]
   })
 
   // type

--- a/cms/migrate/03-create-video.js
+++ b/cms/migrate/03-create-video.js
@@ -12,7 +12,12 @@ module.exports = function(migration) {
   video.createField('name', {
     name: 'Name',
     type: 'Symbol',
-    required: true
+    required: true,
+    validations: [
+      {
+        prohibitRegexp: { pattern: '\.|\s|[A-Z]' }
+      }
+    ]
   })
 
   video.createField('training_module', {
@@ -57,13 +62,6 @@ module.exports = function(migration) {
     ]
   })
 
-
-  video.createField('title', {
-    name: 'Title',
-    type: 'Text',
-    required: true
-  })
-  
   video.createField('heading', {
     name: 'Heading',
     type: 'Text',
@@ -75,7 +73,13 @@ module.exports = function(migration) {
     type: 'Text',
     required: true
   })
-  
+
+  video.createField('title', {
+    name: 'Title',
+    type: 'Text',
+    required: true
+  })
+
   video.createField('transcript', {
     name: 'Transcript',
     type: 'Text',
@@ -101,4 +105,11 @@ module.exports = function(migration) {
       }
     ]
   })
+
+  /* Interface -------------------------------------------------------------- */
+
+  video.changeFieldControl('title', 'builtin', 'singleLine', {
+    helpText: 'Video title is often identical to heading',
+  })
+
 }

--- a/cms/migrate/03-create-video.js
+++ b/cms/migrate/03-create-video.js
@@ -108,7 +108,11 @@ module.exports = function(migration) {
 
   /* Interface -------------------------------------------------------------- */
 
-  video.changeFieldControl('title', 'builtin', 'singleLine', {
+  video.changeFieldControl('heading', 'builtin', 'multipleLine', {
+    helpText: 'foo',
+  })
+
+  video.changeFieldControl('title', 'builtin', 'multipleLine', {
     helpText: 'Video title is often identical to heading',
   })
 

--- a/cms/migrate/03-create-video.js
+++ b/cms/migrate/03-create-video.js
@@ -15,7 +15,7 @@ module.exports = function(migration) {
     required: true,
     validations: [
       {
-        prohibitRegexp: { pattern: '\.|\s|[A-Z]' }
+        prohibitRegexp: { pattern: '\\.|\\s|[A-Z]' }
       }
     ]
   })

--- a/cms/migrate/04-create-training-module.js
+++ b/cms/migrate/04-create-training-module.js
@@ -142,7 +142,7 @@ module.exports = function(migration) {
 
   /* Interface -------------------------------------------------------------- */
 
-  trainingModule.changeFieldControl('pages', 'builtin', 'entryLinksEditor', {
+  trainingModule.changeFieldControl('pages', 'builtin', 'entryCardsEditor', {
     helpText: 'Define module content and order here',
   })
 

--- a/lib/seed_course_entries.rb
+++ b/lib/seed_course_entries.rb
@@ -101,10 +101,8 @@ private
   # @return [Contentful::Management::DynamicEntry]
   def create_entry(item)
     case item.type
-    when /video/
-      create_video item.cms_video_params
-    when /question/
-      create_question item.cms_question_params
+    when /video/    then create_video item.cms_video_params
+    when /question/ then create_question item.cms_question_params
     else
       create_page item.cms_page_params
     end

--- a/terraform/workspace-variables/app_config.yml
+++ b/terraform/workspace-variables/app_config.yml
@@ -53,7 +53,7 @@ content:
   # cms
   # CONTENTFUL_PREVIEW: true
   # CONTENTFUL: false
-  CONTENTFUL_ENVIRONMENT: images
+  CONTENTFUL_ENVIRONMENT: jack
   # @see .github/workflows/content.yml
   # DOMAIN: xxx.london.cloudapps.digital
   # GOVUK_WEBSITE_ROOT: xxx


### PR DESCRIPTION
- add default value for answer JSON field to facilitate previewing questions as they are authored 
- reorder video fields and add help text (this can also be achieved in Compose)
- use card view for selecting module content which includes page type
- add Page, Video and Question 'name' validation to prevent spaces, dots and capitals
- rescue question response lookup when there is no equivalent in YAML
- reenable integrity check for thumbnail images

<img width="738" alt="Screenshot 2023-06-07 at 14 52 39" src="https://github.com/DFE-Digital/early-years-foundation-recovery/assets/3261/15edda71-3d3f-4eb3-8189-a29dd5ed121b">
