### PR TITLE
Revert to Devise default, which uses :html and :turbo_stream

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -300,7 +300,7 @@ Devise.setup do |config|
   # should add them to the navigational formats lists.
   #
   # The "*/*" below is required to match Internet Explorer requests.
-  config.navigational_formats = ['*/*', :html]
+  # config.navigational_formats = ['*/*', :html, :turbo_stream]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :get


### PR DESCRIPTION
The default for Devise ~4.9 is to use :html and :turbo_stream but we were overriding it with just :html.  I've updated to use the default.

[ER-647](https://dfedigital.atlassian.net/browse/ER-647)
[ER-648](https://dfedigital.atlassian.net/browse/ER-648)


[ER-647]: https://dfedigital.atlassian.net/browse/ER-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ER-648]: https://dfedigital.atlassian.net/browse/ER-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ