### PR TITLE
Avoid failing logic if topic is zero

### DIFF
--- a/app/decorators/contentful_module_overview_decorator.rb
+++ b/app/decorators/contentful_module_overview_decorator.rb
@@ -112,6 +112,8 @@ private
   # @return [Boolean]
   def clickable?(submodule:, subsection_item:)
     return all?([subsection_item]) if submodule.zero?
+    
+    return false if subsection_item.topic.zero?
 
     submodule_intro = fetch_submodule(submodule).first
     return false unless visited?(submodule_intro)


### PR DESCRIPTION
Right now, when the topic is zero the fetch to Contentful fails as `content_by_submodule_topic` specifically excludes any topics that are zero.

Need better understanding of what a topic zero is and why it is excluded from this `clickable?` method - business intent for this is not self-evident from the code itself.