### PR TITLE
ER-698: Script to deploy background worker

### DIFF
--- a/.github/workflows/azure-deploy-dev.yml
+++ b/.github/workflows/azure-deploy-dev.yml
@@ -87,7 +87,6 @@ jobs:
 
       # Deploy Background Worker
       - name: Deploy to Azure Container Instances
-        if: ${{ vars.ENVIRONMENT == 'development' }}
         uses: azure/CLI@v1
         with:
           azcliversion: 2.50.0

--- a/.github/workflows/azure-deploy-dev.yml
+++ b/.github/workflows/azure-deploy-dev.yml
@@ -87,9 +87,20 @@ jobs:
 
       # Deploy Background Worker
       - name: Deploy to Azure Container Instances
-        uses: azure/aci-deploy@v1
+        if: ${{ vars.ENVIRONMENT == 'development' }}
+        uses: azure/CLI@v1
         with:
-          resource-group: ${{ secrets.AZURE_RESOURCE_GROUP }}
-          image: ${{ env.DOCKER_IMAGE }}:${{ github.sha }}
-          name: eyrecovery-worker
-          location: 'west europe'
+          azcliversion: 2.50.0
+          inlineScript: |
+            az container create --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
+              --name eyrecovery-worker \
+              --image ${{ env.DOCKER_IMAGE }}:${{ github.sha }} \
+              --cpu 1 \
+              --memory 2 \
+              --command-line "bundle exec que" \
+              --restart-policy OnFailure \
+              --log-analytics-workspace ${{ secrets.AZURE_LOG_ANALYTICS_WORKSPACE }} \
+              --vnet ${{ secrets.AZURE_VNET }} \
+              --subnet ${{ secrets.AZURE_WORKER_APP_SUBNET }} \
+              --ip-address Private \
+              --environment-variables RAILS_ENV=${{ vars.WEBAPP_CONFIG_RAILS_ENV }} RAILS_MASTER_KEY=${{ secrets.WEBAPP_CONFIG_RAILS_MASTER_KEY }} RAILS_LOG_TO_STDOUT=${{ vars.WEBAPP_CONFIG_RAILS_LOG_TO_STDOUT }} GOOGLE_CLOUD_BUCKET=${{ vars.WEBAPP_CONFIG_GOOGLE_CLOUD_BUCKET }} DATABASE_URL=${{ secrets.WEBAPP_DATABASE_URL }} GOVUK_APP_DOMAIN=localhost GOVUK_WEBSITE_ROOT=www

--- a/.github/workflows/tf-azure-deploy-dev.yml
+++ b/.github/workflows/tf-azure-deploy-dev.yml
@@ -21,35 +21,35 @@ env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-  TF_VAR_environment: ${{ vars.TF_VAR_ENVIRONMENT }}
-  TF_VAR_resource_name_prefix: ${{ vars.TF_VAR_RESOURCE_PREFIX }}
-  TF_VAR_psqlfs_sku: ${{ vars.TF_VAR_PSQLFS_SKU }}
-  TF_VAR_psqlfs_storage: ${{ vars.TF_VAR_PSQLFS_STORAGE }}
-  TF_VAR_psqlfs_username: ${{ secrets.TF_VAR_PSQLFS_USERNAME }}
-  TF_VAR_psqlfs_password: ${{ secrets.TF_VAR_PSQLFS_PASSWORD }}
-  TF_VAR_psqlfs_geo_redundant_backup: ${{ vars.TF_VAR_PSQLFS_GEO_REDUNDANT_BACKUP }}
-  TF_VAR_asp_sku: ${{ vars.TF_VAR_ASP_SKU }}
+  TF_VAR_environment: ${{ vars.ENVIRONMENT }}
+  TF_VAR_resource_name_prefix: ${{ vars.RESOURCE_PREFIX }}
+  TF_VAR_psqlfs_sku: ${{ vars.PSQLFS_SKU }}
+  TF_VAR_psqlfs_storage: ${{ vars.PSQLFS_STORAGE }}
+  TF_VAR_psqlfs_username: ${{ secrets.PSQLFS_USERNAME }}
+  TF_VAR_psqlfs_password: ${{ secrets.PSQLFS_PASSWORD }}
+  TF_VAR_psqlfs_geo_redundant_backup: ${{ vars.PSQLFS_GEO_REDUNDANT_BACKUP }}
+  TF_VAR_asp_sku: ${{ vars.ASP_SKU }}
   TF_VAR_webapp_name: ${{ vars.WEBAPP_NAME }}
-  TF_VAR_webapp_database_url: ${{ secrets.TF_VAR_WEBAPP_DATABASE_URL }}
+  TF_VAR_webapp_database_url: ${{ secrets.WEBAPP_DATABASE_URL }}
   TF_VAR_webapp_docker_registry_url: https://ghcr.io
   TF_VAR_webapp_docker_image: dfe-digital/early-years-foundation-recovery
   TF_VAR_webapp_docker_image_tag: latest
-  TF_VAR_webapp_config_bot_token: ${{ secrets.TF_VAR_WEBAPP_CONFIG_BOT_TOKEN }}
-  TF_VAR_webapp_config_contentful_environment: ${{ vars.TF_VAR_WEBAPP_CONFIG_CONTENTFUL_ENVIRONMENT }}
-  TF_VAR_webapp_config_contentful_preview: ${{ vars.TF_VAR_WEBAPP_CONFIG_CONTENTFUL_PREVIEW }}
-  TF_VAR_webapp_config_domain: ${{ vars.TF_VAR_WEBAPP_CONFIG_DOMAIN }}
-  TF_VAR_webapp_config_editor: ${{ vars.TF_VAR_WEBAPP_CONFIG_EDITOR }}
-  TF_VAR_webapp_config_feedback_url: ${{ vars.TF_VAR_WEBAPP_CONFIG_FEEDBACK_URL }}
-  TF_VAR_webapp_config_grover_no_sandbox: ${{ vars.TF_VAR_WEBAPP_CONFIG_GROVER_NO_SANDBOX }}
-  TF_VAR_webapp_config_google_cloud_bucket: ${{ vars.TF_VAR_WEBAPP_CONFIG_GOOGLE_CLOUD_BUCKET }}
-  TF_VAR_webapp_config_node_env: ${{ vars.TF_VAR_WEBAPP_CONFIG_NODE_ENV }}
-  TF_VAR_webapp_config_rails_env: ${{ vars.TF_VAR_WEBAPP_CONFIG_RAILS_ENV }}
-  TF_VAR_webapp_config_rails_log_to_stdout: ${{ vars.TF_VAR_WEBAPP_CONFIG_RAILS_LOG_TO_STDOUT }}
-  TF_VAR_webapp_config_rails_master_key: ${{ secrets.TF_VAR_WEBAPP_CONFIG_RAILS_MASTER_KEY }}
-  TF_VAR_webapp_config_rails_max_threads: ${{ vars.TF_VAR_WEBAPP_CONFIG_RAILS_MAX_THREADS }}
-  TF_VAR_webapp_config_rails_serve_static_files: ${{ vars.TF_VAR_WEBAPP_CONFIG_RAILS_SERVE_STATIC_FILES }}
-  TF_VAR_webapp_config_training_modules: ${{ vars.TF_VAR_WEBAPP_CONFIG_TRAINING_MODULES }}
-  TF_VAR_webapp_config_web_concurrency: ${{ vars.TF_VAR_WEBAPP_CONFIG_WEB_CONCURRENCY }}
+  TF_VAR_webapp_config_bot_token: ${{ secrets.WEBAPP_CONFIG_BOT_TOKEN }}
+  TF_VAR_webapp_config_contentful_environment: ${{ vars.WEBAPP_CONFIG_CONTENTFUL_ENVIRONMENT }}
+  TF_VAR_webapp_config_contentful_preview: ${{ vars.WEBAPP_CONFIG_CONTENTFUL_PREVIEW }}
+  TF_VAR_webapp_config_domain: ${{ vars.WEBAPP_CONFIG_DOMAIN }}
+  TF_VAR_webapp_config_editor: ${{ vars.WEBAPP_CONFIG_EDITOR }}
+  TF_VAR_webapp_config_feedback_url: ${{ vars.WEBAPP_CONFIG_FEEDBACK_URL }}
+  TF_VAR_webapp_config_grover_no_sandbox: ${{ vars.WEBAPP_CONFIG_GROVER_NO_SANDBOX }}
+  TF_VAR_webapp_config_google_cloud_bucket: ${{ vars.WEBAPP_CONFIG_GOOGLE_CLOUD_BUCKET }}
+  TF_VAR_webapp_config_node_env: ${{ vars.WEBAPP_CONFIG_NODE_ENV }}
+  TF_VAR_webapp_config_rails_env: ${{ vars.WEBAPP_CONFIG_RAILS_ENV }}
+  TF_VAR_webapp_config_rails_log_to_stdout: ${{ vars.WEBAPP_CONFIG_RAILS_LOG_TO_STDOUT }}
+  TF_VAR_webapp_config_rails_master_key: ${{ secrets.WEBAPP_CONFIG_RAILS_MASTER_KEY }}
+  TF_VAR_webapp_config_rails_max_threads: ${{ vars.WEBAPP_CONFIG_RAILS_MAX_THREADS }}
+  TF_VAR_webapp_config_rails_serve_static_files: ${{ vars.WEBAPP_CONFIG_RAILS_SERVE_STATIC_FILES }}
+  TF_VAR_webapp_config_training_modules: ${{ vars.WEBAPP_CONFIG_TRAINING_MODULES }}
+  TF_VAR_webapp_config_web_concurrency: ${{ vars.WEBAPP_CONFIG_WEB_CONCURRENCY }}
 
 jobs:
   terraform-plan:

--- a/terraform-azure/local.tf
+++ b/terraform-azure/local.tf
@@ -37,12 +37,12 @@ locals {
 
   # Background Worker Application Configuration
   app_worker_environment_variables = {
-    "DATABASE_URL"                        = var.webapp_database_url
-    "GOVUK_APP_DOMAIN"                    = "london.cloudapps.digital" #TODO: Remove this dependency post-migration to Azure
-    "GOVUK_WEBSITE_ROOT"                  = "ey-recovery-dev"          #TODO: Remove this dependency post-migration to Azure
-    "GOOGLE_CLOUD_BUCKET"                 = var.webapp_config_google_cloud_bucket
-    "RAILS_ENV"                           = var.webapp_config_rails_env
-    "RAILS_LOG_TO_STDOUT"                 = var.webapp_config_rails_log_to_stdout
-    "RAILS_MASTER_KEY"                    = var.webapp_config_rails_master_key
+    "DATABASE_URL"        = var.webapp_database_url
+    "GOVUK_APP_DOMAIN"    = "london.cloudapps.digital" #TODO: Remove this dependency post-migration to Azure
+    "GOVUK_WEBSITE_ROOT"  = "ey-recovery-dev"          #TODO: Remove this dependency post-migration to Azure
+    "GOOGLE_CLOUD_BUCKET" = var.webapp_config_google_cloud_bucket
+    "RAILS_ENV"           = var.webapp_config_rails_env
+    "RAILS_LOG_TO_STDOUT" = var.webapp_config_rails_log_to_stdout
+    "RAILS_MASTER_KEY"    = var.webapp_config_rails_master_key
   }
 }

--- a/terraform-azure/local.tf
+++ b/terraform-azure/local.tf
@@ -10,7 +10,7 @@ locals {
     "Service Offering" = "EY Recovery"
   }
 
-  # Web App Configuration
+  # Web Application Configuration
   webapp_app_settings = {
     "DATABASE_URL"                        = var.webapp_database_url
     "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false"
@@ -33,5 +33,16 @@ locals {
     "TRAINING_MODULES"                    = var.webapp_config_training_modules
     "WEB_CONCURRENCY"                     = var.webapp_config_web_concurrency
     "WEBSITES_CONTAINER_START_TIME_LIMIT" = 1800
+  }
+
+  # Background Worker Application Configuration
+  app_worker_environment_variables = {
+    "DATABASE_URL"                        = var.webapp_database_url
+    "GOVUK_APP_DOMAIN"                    = "london.cloudapps.digital" #TODO: Remove this dependency post-migration to Azure
+    "GOVUK_WEBSITE_ROOT"                  = "ey-recovery-dev"          #TODO: Remove this dependency post-migration to Azure
+    "GOOGLE_CLOUD_BUCKET"                 = var.webapp_config_google_cloud_bucket
+    "RAILS_ENV"                           = var.webapp_config_rails_env
+    "RAILS_LOG_TO_STDOUT"                 = var.webapp_config_rails_log_to_stdout
+    "RAILS_MASTER_KEY"                    = var.webapp_config_rails_master_key
   }
 }

--- a/terraform-azure/main.tf
+++ b/terraform-azure/main.tf
@@ -73,9 +73,9 @@ module "app-worker" {
   resource_group                   = azurerm_resource_group.rg.name
   resource_name_prefix             = "${var.resource_name_prefix}-worker"
   app_worker_subnet_id             = module.network.app_worker_subnet_id
-  app_worker_name                  = "${var.webapp_name}-worker"
+  app_worker_name                  = "eyrecovery-worker"
   container_name                   = "eyrecovery-worker"
-  app_worker_environment_variables = local.webapp_app_settings
+  app_worker_environment_variables = local.app_worker_environment_variables
   app_worker_docker_image          = var.webapp_docker_image
   app_worker_docker_image_tag      = var.webapp_docker_image_tag
   app_worker_docker_registry       = "ghcr.io"


### PR DESCRIPTION
This change is necessary as the Azure GitHub Action for ACI doesn't support Private containers for deploying