### PR TITLE
ER-697: Patch Review Apps and Staging workflow

### DIFF
--- a/.github/workflows/azure-deploy-dev.yml
+++ b/.github/workflows/azure-deploy-dev.yml
@@ -19,6 +19,10 @@ on:
       - terraform-azure/**
       - uml/*
 
+# Permissions for OIDC authentication
+permissions:
+  id-token: write
+
 env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/azure-deploy-review-teardown.yml
+++ b/.github/workflows/azure-deploy-review-teardown.yml
@@ -5,6 +5,10 @@ on:
     types:
       - closed
 
+# Permissions for OIDC authentication
+permissions:
+  id-token: write
+
 env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/azure-deploy-review.yml
+++ b/.github/workflows/azure-deploy-review.yml
@@ -65,9 +65,9 @@ jobs:
           context: .
           build-args: BUILDKIT_INLINE_CACHE=1
           cache-from: |
-            ${{ env.REGISTRY }}:deps
+            ${{ env.DOCKER_IMAGE }}:deps
           push: true
-          tags: ${{ env.REGISTRY }}:deps
+          tags: ${{ env.DOCKER_IMAGE }}:deps
           target: deps
 
       - name: Build and push Docker image
@@ -80,12 +80,12 @@ jobs:
             BUILDKIT_INLINE_CACHE=1
             SHA=${{ github.event.pull_request.head.sha }}
           cache-from: |
-            ${{ env.REGISTRY }}:${{ github.event.pull_request.head.sha }}
-            ${{ env.REGISTRY }}:${{ env.PR_NUMBER }}
-            ${{ env.REGISTRY }}:latest
+            ${{ env.DOCKER_IMAGE }}:${{ github.event.pull_request.head.sha }}
+            ${{ env.DOCKER_IMAGE }}:${{ env.PR_NUMBER }}
+            ${{ env.DOCKER_IMAGE }}:latest
           tags: |
-            ${{ env.REGISTRY }}:${{ github.event.pull_request.head.sha }}
-            ${{ env.REGISTRY }}:${{ env.PR_NUMBER }}
+            ${{ env.DOCKER_IMAGE }}:${{ github.event.pull_request.head.sha }}
+            ${{ env.DOCKER_IMAGE }}:${{ env.PR_NUMBER }}
 
       # Login to Azure using OIDC
       - name: Login to Azure CLI

--- a/.github/workflows/azure-deploy-review.yml
+++ b/.github/workflows/azure-deploy-review.yml
@@ -20,6 +20,10 @@ on:
       - terraform-azure
       - uml/*
 
+# Permissions for OIDC authentication
+permissions:
+  id-token: write
+
 env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/azure-deploy-stage.yml
+++ b/.github/workflows/azure-deploy-stage.yml
@@ -15,7 +15,11 @@ on:
   push:
     tags:
       - rc*
-      - 
+
+# Permissions for OIDC authentication
+permissions:
+  id-token: write
+
 env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/tf-azure-deploy.yml
+++ b/.github/workflows/tf-azure-deploy.yml
@@ -23,6 +23,10 @@ defaults:
   run:
     working-directory: ./terraform-azure
 
+# Permissions for OIDC authentication
+permissions:
+  id-token: write
+
 env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/terraform-azure/terraform-azure-review/main.tf
+++ b/terraform-azure/terraform-azure-review/main.tf
@@ -36,10 +36,6 @@ resource "azurerm_linux_web_app" "review-app" {
     }
   }
 
-  sticky_settings {
-    app_setting_names = keys(var.webapp_app_settings)
-  }
-
   logs {
     detailed_error_messages = true
     failed_request_tracing  = true


### PR DESCRIPTION
- Corrected environment variable name for the container image in the Review Apps workflow
- Reinstated OIDC permission in the Staging workflow
- Removed Sticky settings from Review App Terraform script due to a known bug where the behaviour to clone app configuration is different in the CLI to to that in Portal (ref. https://github.com/Azure/azure-cli/issues/6638)