### PR TITLE
Remove continue training mail job

### DIFF
--- a/app/models/data/user_overview.rb
+++ b/app/models/data/user_overview.rb
@@ -28,7 +28,7 @@ module Data
           'Without Notes Percentage',
           'Complete Registration Mail Recipients',
           'Start Training Mail Recipients',
-          'Continue Training Mail Recipients',
+          # 'Continue Training Mail Recipients',
           'New Module Mail Recipients',
         ]
       end
@@ -58,7 +58,7 @@ module Data
           without_notes_percentage: 1 - with_notes_percentage,
           complete_registration_mail_recipients: CompleteRegistrationMailJob.recipients.count,
           start_training_mail_recipients: StartTrainingMailJob.recipients.count,
-          continue_training_mail_recipients: ContinueTrainingMailJob.recipients.count,
+          # continue_training_mail_recipients: ContinueTrainingMailJob.recipients.count,
           new_module_mail_recipients: NewModuleMailJob.recipients.count,
         }]
       end

--- a/config/initializers/que.rb
+++ b/config/initializers/que.rb
@@ -3,7 +3,7 @@ Que::Scheduler.configure do |config|
     DashboardJob: { cron: Rails.application.config.dashboard_update_interval },
     CompleteRegistrationMailJob: { cron: Rails.application.config.mail_job_interval },
     StartTrainingMailJob: { cron: Rails.application.config.mail_job_interval },
-    ContinueTrainingMailJob: { cron: Rails.application.config.mail_job_interval },
+    # ContinueTrainingMailJob: { cron: Rails.application.config.mail_job_interval },
   }
 end
 

--- a/spec/models/data/user_overview_spec.rb
+++ b/spec/models/data/user_overview_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Data::UserOverview do
       'Without Notes Percentage',
       'Complete Registration Mail Recipients',
       'Start Training Mail Recipients',
-      'Continue Training Mail Recipients',
+      # 'Continue Training Mail Recipients',
       'New Module Mail Recipients',
     ]
   end
@@ -55,7 +55,7 @@ RSpec.describe Data::UserOverview do
         without_notes_percentage: 0.5,
         complete_registration_mail_recipients: 1,
         start_training_mail_recipients: 1,
-        continue_training_mail_recipients: 0,
+        # continue_training_mail_recipients: 0,
         new_module_mail_recipients: 2,
       },
     ]


### PR DESCRIPTION
Comment out continue training mail job. Job is slow running and is being removed until we have a more performant alternative