### PR TITLE
Email preferences wording fix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,7 @@ class ApplicationController < ActionController::Base
 
   def authenticate_registered_user!
     authenticate_user! unless user_signed_in?
+    current_user.update!(last_logged_in_at: Time.zone.now)
     return true if current_user.registration_complete?
 
     redirect_to edit_registration_name_path, notice: 'Please complete registration'

--- a/app/jobs/historical_complete_registration_mail_job.rb
+++ b/app/jobs/historical_complete_registration_mail_job.rb
@@ -1,0 +1,7 @@
+class HistoricalCompleteRegistrationMailJob < MailJob
+  def run
+    super do
+      self.class.recipients.each(&:send_complete_registration_notification)
+    end
+  end
+end

--- a/app/jobs/historical_start_training_mail_job.rb
+++ b/app/jobs/historical_start_training_mail_job.rb
@@ -1,0 +1,7 @@
+class HistoricalStartTrainingMailJob < MailJob
+  def run
+    super do
+      self.class.recipients.each(&:send_start_training_notification)
+    end
+  end
+end

--- a/app/jobs/populate_last_logged_in_at_job.rb
+++ b/app/jobs/populate_last_logged_in_at_job.rb
@@ -1,0 +1,18 @@
+class PopulateLastLoggedInAtJob < ApplicationJob
+  def run
+    super do
+      update_last_logged_in_at
+    end
+  end
+
+  def update_last_logged_in_at
+    User.find_in_batches(batch_size: 1000) do |users|
+      users.each do |user|
+        break unless user.last_logged_in_at.nil?
+
+        last_visit = Ahoy::Visit.where(user_id: user.id).order(started_at: :desc).first
+        user.update!(last_logged_in_at: last_visit.started_at) if last_visit
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,6 +75,7 @@ class User < ApplicationRecord
   scope :not_started_training, -> { reject(&:course_started?) }
   scope :course_in_progress, -> { select(&:course_in_progress?) }
 
+  scope :pre_nudge_mail_confimation, -> { where("confirmed_at < ?", Rails.application.nudge_email_launch_date - 4.weeks) }
   scope :training_email_recipients, -> { where(training_emails: [true, nil]) }
   scope :early_years_email_recipients, -> { where(early_years_emails: true) }
   scope :without_notes, -> { where.not(id: with_notes) }
@@ -91,6 +92,8 @@ class User < ApplicationRecord
   scope :complete_registration_mail_job_recipients, -> { order(:id).training_email_recipients.month_old_confirmation.registration_incomplete }
   scope :continue_training_mail_job_recipients, -> { order(:id).training_email_recipients.select(&:continue_training_recipient?) }
   scope :new_module_mail_job_recipients, -> { order(:id).training_email_recipients.select(&:completed_available_modules?) }
+  scope :historical_start_training_mail_job_recipients, -> { order(:id).training_email_recipients.pre_nudge_mail_confimation.registration_complete.not_started_training }
+  scope :historical_complete_registration_mail_job_recipients, -> { order(:id).training_email_recipients.pre_nudge_mail_confimation.registration_incomplete }
 
   scope :dashboard, -> { not_closed }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,7 +75,7 @@ class User < ApplicationRecord
   scope :not_started_training, -> { reject(&:course_started?) }
   scope :course_in_progress, -> { select(&:course_in_progress?) }
 
-  scope :pre_nudge_mail_confimation, -> { where("confirmed_at < ?", Rails.application.nudge_email_launch_date - 4.weeks) }
+  scope :pre_nudge_mail_confirmation, -> { where("confirmed_at < ?", Rails.application.nudge_email_launch_date - 4.weeks) }
   scope :training_email_recipients, -> { where(training_emails: [true, nil]) }
   scope :early_years_email_recipients, -> { where(early_years_emails: true) }
   scope :without_notes, -> { where.not(id: with_notes) }
@@ -92,8 +92,8 @@ class User < ApplicationRecord
   scope :complete_registration_mail_job_recipients, -> { order(:id).training_email_recipients.month_old_confirmation.registration_incomplete }
   scope :continue_training_mail_job_recipients, -> { order(:id).training_email_recipients.select(&:continue_training_recipient?) }
   scope :new_module_mail_job_recipients, -> { order(:id).training_email_recipients.select(&:completed_available_modules?) }
-  scope :historical_start_training_mail_job_recipients, -> { order(:id).training_email_recipients.pre_nudge_mail_confimation.registration_complete.not_started_training }
-  scope :historical_complete_registration_mail_job_recipients, -> { order(:id).training_email_recipients.pre_nudge_mail_confimation.registration_incomplete }
+  scope :historical_start_training_mail_job_recipients, -> { order(:id).training_email_recipients.pre_nudge_mail_confirmation.registration_complete.not_started_training }
+  scope :historical_complete_registration_mail_job_recipients, -> { order(:id).training_email_recipients.pre_nudge_mail_confirmation.registration_incomplete }
 
   scope :dashboard, -> { not_closed }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,7 +75,7 @@ class User < ApplicationRecord
   scope :not_started_training, -> { reject(&:course_started?) }
   scope :course_in_progress, -> { select(&:course_in_progress?) }
 
-  scope :pre_nudge_mail_confirmation, -> { where("confirmed_at < ?", Rails.application.nudge_email_launch_date - 4.weeks) }
+  scope :pre_nudge_mail_confirmation, -> { where('confirmed_at < ?', Rails.application.nudge_email_launch_date - 4.weeks) }
   scope :training_email_recipients, -> { where(training_emails: [true, nil]) }
   scope :early_years_email_recipients, -> { where(early_years_emails: true) }
   scope :without_notes, -> { where.not(id: with_notes) }
@@ -370,9 +370,7 @@ class User < ApplicationRecord
   def continue_training_recipient?
     return false unless course_in_progress?
 
-    recent_visits = Ahoy::Visit.last_4_weeks
-    old_visits = Ahoy::Visit.month_old.reject { |visit| recent_visits.pluck(:user_id).include?(visit.user_id) }
-    old_visits.pluck(:user_id).include?(id)
+    !last_logged_in_at.nil? && last_logged_in_at < 4.weeks.ago
   end
 
 private

--- a/app/views/user/show.html.slim
+++ b/app/views/user/show.html.slim
@@ -44,7 +44,7 @@
         - row.with_value { nil }
       - email_preferences.with_row do |row|
         - row.with_key { 'Email updates about this training course' }
-        - row.with_value(text: current_user.training_emails.nil? || current_user.training_emails ? t('.training_emails_true') : t('.training_emails_false'), classes: ['data-hj-suppress'])
+        - row.with_value(text: current_user.training_emails.nil? || current_user.training_emails ? t('my_account.training_emails_true') : t('my_account.training_emails_false'), classes: ['data-hj-suppress'])
         - row.with_action(text: t('links.change'), href: edit_training_emails_user_path, visually_hidden_text: 'training_emails', html_attributes: { id: :edit_training_emails_user })
 
     = content_resource 'my_account.closing.information'

--- a/config/application.rb
+++ b/config/application.rb
@@ -125,5 +125,9 @@ module EarlyYearsFoundationRecovery
     def non_linear_launch_date
       Time.zone.local(2023, 7, 10, 15, 43, 0)
     end
+
+    def nudge_email_launch_date
+      Time.zone.local(2023, 9, 11, 15, 30, 0)
+    end
   end
 end

--- a/db/migrate/20230912124513_add_last_logged_in_at_to_users.rb
+++ b/db/migrate/20230912124513_add_last_logged_in_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastLoggedInAtToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :last_logged_in_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_23_163600) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_12_124513) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -228,6 +228,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_23_163600) do
     t.string "closed_reason_custom"
     t.boolean "training_emails"
     t.boolean "early_years_emails"
+    t.datetime "last_logged_in_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/jobs/continue_training_mail_job_spec.rb
+++ b/spec/jobs/continue_training_mail_job_spec.rb
@@ -1,48 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe ContinueTrainingMailJob do
-  include_context 'with progress'
-
   let(:template) { :continue_training }
 
-  let(:user) { create(:user, :registered, confirmed_at: 4.weeks.ago) }
+  let(:user) do
+    create :user, :registered,
+           confirmed_at: 8.weeks.ago,
+           last_logged_in_at: 4.weeks.ago,
+           module_time_to_completion: { alpha: 0 }
+  end
 
   let(:user_2) do
     create :user, :registered,
-           confirmed_at: 4.weeks.ago,
+           confirmed_at: 8.weeks.ago,
+           last_logged_in_at: 4.weeks.ago,
+           module_time_to_completion: { alpha: 0 }
+  end
+
+  let(:user_3) do
+    create :user, :registered,
+           confirmed_at: 8.weeks.ago,
+           last_logged_in_at: nil,
            module_time_to_completion: { alpha: 0 }
   end
 
   let(:included) { [user] }
   let(:excluded) { [user_2] }
 
-  # Must have started, but not completed training.
-  # Must be 4 weeks since their last visit
-  # `user_2` won't be included because they have a visit from 2 weeks ago
-  before do
-    create :visit,
-           id: 9,
-           visitor_token: '345',
-           user_id: user.id,
-           started_at: 4.weeks.ago
-
-    create :visit,
-           id: 7,
-           visitor_token: '123',
-           user_id: user_2.id,
-           started_at: 4.weeks.ago
-
-    create :visit,
-           id: 8,
-           visitor_token: '234',
-           user_id: user_2.id,
-           started_at: 2.weeks.ago
-
-    # Travel to 4 weeks ago so that the module start event won't count as a recent visit
-    travel_to 4.weeks.ago
-    start_module(alpha)
-    travel_back
-  end
-
+  # Must have started, but not completed training
+  # Must be 4 weeks since their last_logged_in_at
+  # `user_2` won't be included because they last logged in 2 weeks ago
   it_behaves_like 'an email prompt', nil, Training::Module.by_name(:alpha)
 end

--- a/spec/jobs/historical_complete_registration_mail_job_spec.rb
+++ b/spec/jobs/historical_complete_registration_mail_job_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe HistoricalCompleteRegistrationMailJob do
+  let(:template) { :complete_registration }
+
+  # Must have confirmed email more than 4 weeks before nudge email launch date and not have completed registration
+  let(:included) do
+    create_list :user, 3, confirmed_at: Time.zone.local(2023, 1, 1)
+  end
+
+  let(:excluded) do
+    [
+      create(:user, :registered, confirmed_at: 4.weeks.ago),
+      create(:user, confirmed_at: 2.months.ago),
+      create(:user, confirmed_at: 4.weeks.ago),
+    ]
+  end
+
+  it_behaves_like 'an email prompt'
+end

--- a/spec/jobs/historical_start_training_mail_job_spec.rb
+++ b/spec/jobs/historical_start_training_mail_job_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe HistoricalStartTrainingMailJob do
+  let(:template) { :start_training }
+
+  # Must have confirmed email more than 4 weeks before nudge email launch date, completed registration and not have started training
+  let(:included) do
+    create_list :user, 3, :registered, confirmed_at: Time.zone.local(2023, 1, 1)
+  end
+
+  let(:excluded) do
+    [
+      create(:user, :registered, confirmed_at: 2.months.ago),
+      create(:user, :registered, confirmed_at: 4.weeks.ago, module_time_to_completion: { alpha: 0 }),
+      create(:user, :registered, confirmed_at: 4.weeks.ago),
+    ]
+  end
+
+  it_behaves_like 'an email prompt'
+end

--- a/spec/jobs/populate_last_logged_in_at_job_spec.rb
+++ b/spec/jobs/populate_last_logged_in_at_job_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe PopulateLastLoggedInAtJob do
+  context 'when users have no last_logged_in_at' do
+    let(:user_1) { create(:user, :registered) }
+    let(:user_2) { create(:user, :registered) }
+    let(:user_3) { create(:user, :registered) }
+    let!(:visit_1) { create(:visit, visitor_token: '123', user_id: user_1.id, started_at: 1.day.ago) }
+    let!(:visit_2) { create(:visit, visitor_token: '234', user_id: user_2.id, started_at: 2.days.ago) }
+
+    before do
+      create(:visit, visitor_token: '123', user_id: user_1.id, started_at: 3.days.ago)
+      create(:visit, visitor_token: '123', user_id: user_1.id, started_at: 2.days.ago)
+      described_class.run
+    end
+
+    it 'updates last_logged_in_at with the last visit date' do
+      expect(user_1.reload.last_logged_in_at).to eq(visit_1.started_at)
+      expect(user_2.reload.last_logged_in_at).to eq(visit_2.started_at)
+      expect(user_3.reload.last_logged_in_at).to eq(nil)
+    end
+  end
+end

--- a/spec/jobs/populate_last_logged_in_at_job_spec.rb
+++ b/spec/jobs/populate_last_logged_in_at_job_spec.rb
@@ -20,24 +20,4 @@ RSpec.describe PopulateLastLoggedInAtJob do
       expect(user_3.reload.last_logged_in_at).to eq(nil)
     end
   end
-
-  context 'when users a large number of users have no last_logged_in_at' do
-    let!(:users) { create_list(:user, 1000, :registered) }
-
-    before do
-      users.each do |user|
-        create(:visit, visitor_token: '123', user_id: user.id, started_at: 2.days.ago)
-      end
-    end
-
-    it 'updates last_logged_in_at with the last visit date' do
-      execution_time = Benchmark.realtime do
-        described_class.run
-      end
-      users.each do |user|
-        expect(user.reload.last_logged_in_at).to be_within(1.minute).of(2.days.ago)
-      end
-      expect(execution_time).to be < 10.seconds
-    end
-  end
 end

--- a/spec/jobs/populate_last_logged_in_at_job_spec.rb
+++ b/spec/jobs/populate_last_logged_in_at_job_spec.rb
@@ -20,4 +20,24 @@ RSpec.describe PopulateLastLoggedInAtJob do
       expect(user_3.reload.last_logged_in_at).to eq(nil)
     end
   end
+
+  context 'when users a large number of users have no last_logged_in_at' do
+    let!(:users) { create_list(:user, 1000, :registered) }
+
+    before do
+      users.each do |user|
+        create(:visit, visitor_token: '123', user_id: user.id, started_at: 2.days.ago)
+      end
+    end
+
+    it 'updates last_logged_in_at with the last visit date' do
+      execution_time = Benchmark.realtime do
+        described_class.run
+      end
+      users.each do |user|
+        expect(user.reload.last_logged_in_at).to be_within(1.minute).of(2.days.ago)
+      end
+      expect(execution_time).to be < 10.seconds
+    end
+  end
 end


### PR DESCRIPTION
Correct email preferences wording to use `my_account.training_emails_false` and `my_account.training_emails_true`