### PR TITLE
Big quote markup using bespoke Govspeak tag

### DIFF
--- a/app/assets/stylesheets/quote.scss
+++ b/app/assets/stylesheets/quote.scss
@@ -30,7 +30,7 @@
   
     &:before {
       position: absolute;
-      content: '“';
+      content: '"';
       font-size: 8em;
       margin-top: -0.4em;
       background-color: govuk-colour("white");

--- a/app/views/govspeak/_quote.html.slim
+++ b/app/views/govspeak/_quote.html.slim
@@ -1,0 +1,5 @@
+.blockquote-container
+  blockquote.quote
+    == quote
+
+    cite= citation

--- a/config/initializers/govspeak.rb
+++ b/config/initializers/govspeak.rb
@@ -6,7 +6,6 @@ GOVSPEAK_TEMPLATES = {
 
 # Big Quote
 Govspeak::Document.extension('quote', Govspeak::Document.surrounded_by('$QUOTE')) do |content|
-
   citation = content.split("\n").last
   quote = content.gsub(citation, Types::EMPTY_STRING)
 

--- a/config/initializers/govspeak.rb
+++ b/config/initializers/govspeak.rb
@@ -1,7 +1,22 @@
 GOVSPEAK_TEMPLATES = {
   prompt: Slim::Template.new('app/views/govspeak/_prompt.html.slim'),
   video: Slim::Template.new('app/views/govspeak/_video.html.slim'),
+  quote: Slim::Template.new('app/views/govspeak/_quote.html.slim'),
 }.freeze
+
+# Big Quote
+Govspeak::Document.extension('quote', Govspeak::Document.surrounded_by('$QUOTE')) do |content|
+
+  citation = content.split("\n").last
+  quote = content.gsub(citation, Types::EMPTY_STRING)
+
+  locals = {
+    quote: Govspeak::Document.to_html(quote),
+    citation: citation,
+  }
+
+  GOVSPEAK_TEMPLATES[:quote].render(nil, locals)
+end
 
 # Custom Practitioner Prompts
 %i[info book brain].each do |icon|

--- a/spec/helpers/content_helper_spec.rb
+++ b/spec/helpers/content_helper_spec.rb
@@ -124,9 +124,9 @@ describe 'ContentHelper', type: :helper do
         let(:input) do
           <<~QUOTE
             $QUOTE
-            a bird in the hand is worth two in the bush
+            Life is trying things to see if they work.
 
-            anon
+            Ray Bradbury
             $QUOTE
           QUOTE
         end
@@ -134,9 +134,9 @@ describe 'ContentHelper', type: :helper do
         it 'builds semantic markup' do
           expect(html).to eq <<~QUOTE
             <div class="blockquote-container"><blockquote class="quote">
-            <p>a bird in the hand is worth two in the bush</p>
+            <p>Life is trying things to see if they work.</p>
 
-            <cite>anon</cite>
+            <cite>Ray Bradbury</cite>
             </blockquote></div>
           QUOTE
         end

--- a/spec/helpers/content_helper_spec.rb
+++ b/spec/helpers/content_helper_spec.rb
@@ -119,6 +119,28 @@ describe 'ContentHelper', type: :helper do
           expect(html).to include '<li>one</li>'
         end
       end
+
+      describe 'Big quote prompt' do
+        let(:input) do
+          <<~QUOTE
+            $QUOTE
+            a bird in the hand is worth two in the bush
+
+            anon
+            $QUOTE
+          QUOTE
+        end
+
+        it 'builds semantic markup' do
+          expect(html).to eq <<~QUOTE
+            <div class="blockquote-container"><blockquote class="quote">
+            <p>a bird in the hand is worth two in the bush</p>
+
+            <cite>anon</cite>
+            </blockquote></div>
+          QUOTE
+        end
+      end
     end
   end
 


### PR DESCRIPTION
[ER-443]

https://app.contentful.com/spaces/dvmeh832nmjc/environments/master/entries/2o8yybdQwLV20OTXYux48c
https://ey-recovery-staging.london.cloudapps.digital/modules/module-6/content-pages/6-1-1-1
http://localhost:3000/modules/alpha-clone/content-pages/1-1 (preview only)


```
$QUOTE
this is the quote

this is the citation
$QUOTE
```

<img width="615" alt="Screenshot 2023-09-21 at 12 27 41" src="https://github.com/DFE-Digital/early-years-foundation-recovery/assets/3261/1f119e32-cd55-4358-b8d4-29ab6008e423">

[ER-443]: https://dfedigital.atlassian.net/browse/ER-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ