### PR TITLE
additional fix for continue training nudge mail scope

### DIFF
--- a/spec/jobs/continue_training_mail_job_spec.rb
+++ b/spec/jobs/continue_training_mail_job_spec.rb
@@ -13,8 +13,14 @@ RSpec.describe ContinueTrainingMailJob do
            module_time_to_completion: { alpha: 0 }
   end
 
+  let(:user_3) do
+    create :user, :registered,
+           confirmed_at: 4.weeks.ago,
+           module_time_to_completion: { alpha: 0 }
+  end
+
   let(:included) { [user] }
-  let(:excluded) { [user_2] }
+  let(:excluded) { [user_2, user_3] }
 
   # Must have started, but not completed training.
   # Must be 4 weeks since their last visit
@@ -37,6 +43,12 @@ RSpec.describe ContinueTrainingMailJob do
            visitor_token: '234',
            user_id: user_2.id,
            started_at: 2.weeks.ago
+
+    create :visit,
+           id: 10,
+           visitor_token: '456',
+           user_id: user_3.id,
+           started_at: 5.weeks.ago
 
     # Travel to 4 weeks ago so that the module start event won't count as a recent visit
     travel_to 4.weeks.ago

--- a/spec/models/data/user_overview_spec.rb
+++ b/spec/models/data/user_overview_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Data::UserOverview do
         without_notes_percentage: 0.6,
         complete_registration_mail_recipients: 1,
         start_training_mail_recipients: 1,
-        continue_training_mail_recipients: 4,
+        continue_training_mail_recipients: 0,
         new_module_mail_recipients: 1,
       },
     ]


### PR DESCRIPTION
Update `continue_training_mail_job_recipients` scope so that it is more discerning and selects only users who last visited 4 weeks ago