### PR TITLE
Change label text for audit and move to locales

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -32,7 +32,7 @@ module LinkHelper
 
     govuk_button_link_to content.next_button_text, training_module_page_path(mod.name, page.name),
                          id: 'next-action',
-                         aria: { label: 'Go to the next page' }
+                         aria: { label: t('pagination.next') }
   end
 
   # @return [String] previous page or module overview
@@ -48,7 +48,7 @@ module LinkHelper
 
     govuk_button_link_to 'Previous', path,
                          class: style,
-                         aria: { label: 'Go to the previous page' }
+                         aria: { label: t('pagination.previous') }
   end
 
   # Bottom of my-modules card component

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,6 +101,8 @@ en:
   pagination:
     section: Section %{current} of %{total}
     page: Page %{current} of %{total}
+    previous: Previous Page
+    next: Next Page
 
   na: Not applicable
 

--- a/spec/lib/seed_snippets_spec.rb
+++ b/spec/lib/seed_snippets_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SeedSnippets do
   subject(:locales) { described_class.new.call }
 
   it 'converts all translations' do
-    expect(locales.count).to be 174
+    expect(locales.count).to be 176
   end
 
   it 'dot separated key -> Page::Resource#name' do


### PR DESCRIPTION
[ER-819]

Change `next` and `previous` link labels to improve accessibility

[ER-819]: https://dfedigital.atlassian.net/browse/ER-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ