### PR TITLE
ER-864 card progress bar

### DIFF
--- a/.github/workflows/azure-deploy-review.yml
+++ b/.github/workflows/azure-deploy-review.yml
@@ -20,11 +20,12 @@ on:
       - terraform-azure
       - uml/*
 
-# Permissions for OIDC authentication
+# Permissions for OIDC authentication and URL comment step
 permissions:
   id-token: write
   contents: write
   packages: write
+  pull-requests: write
 
 env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -1,3 +1,32 @@
+/*
+Progress bar
+================================================================================
+*/
+
+.bar-bg {
+  height: 8px;
+  border-radius: 4px;
+}
+
+.bar-progress {
+  height: 10px;
+  top: 10px;
+  border-radius: 4px;
+}
+
+.bar-ball {
+  width: 17px;
+  height: 17px;
+  border-radius: 9px;
+  top: -4px;
+  right: 0;
+}
+
+
+/*
+================================================================================
+*/
+
 .grid-container {
   display: flex;
   flex-direction: column;
@@ -25,13 +54,55 @@
   }
 
   &-container {
-    padding: 20px;
+    padding: govuk-spacing(4);
+
+    .card-progress-bar {
+      color: $govuk-secondary-text-colour;
+      margin-top: auto;
+
+      .percentage {
+        font-size: 16;
+        font-weight: bold;
+      }
+
+      .description {
+        font-size: 14;
+      }
+
+      .bar-settings {
+        padding-top: govuk-spacing(2);
+        padding-bottom: govuk-spacing(2);
+        position: relative;
+      }
+
+      .bar-bg {
+        width: 100%;
+        background-color: $govuk-border-colour;
+      }
+
+      .bar-progress,
+      .bar-ball {
+        background-color: $govuk-success-colour;
+        position: absolute;
+      }
+    }
+
   }
 
   &:hover, &:focus-within {
     background-color: govuk-colour('blue');
-    a {
+
+    a, .percentage, .description {
       color: govuk-colour('white');
+    }
+
+    .bar-bg {
+      background-color: govuk-colour('black');
+    }
+
+    .bar-progress,
+    .bar-ball {
+      background-color: govuk-colour('yellow');
     }
   }
 
@@ -73,6 +144,7 @@
     text-decoration: none;
     color: govuk-colour('blue');
     
+    // TODO: document what this is doing
     &:after {
       position: absolute;
       content: '';

--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -61,12 +61,12 @@ Progress bar
       margin-top: auto;
 
       .percentage {
-        font-size: 16;
+        font-size: 16px;
         font-weight: bold;
       }
 
       .description {
-        font-size: 14;
+        font-size: 14px;
       }
 
       .bar-settings {

--- a/app/controllers/learning_controller.rb
+++ b/app/controllers/learning_controller.rb
@@ -2,10 +2,20 @@
 
 class LearningController < ApplicationController
   before_action :authenticate_registered_user!
+
+  helper_method :module_progress
+
   layout 'hero'
 
   # GET /my-modules
   def show
     track('learning_page')
+  end
+
+private
+
+  # @return [ModuleOverviewDecorator]
+  def module_progress(mod)
+    ModuleOverviewDecorator.new(helpers.module_progress_service(mod))
   end
 end

--- a/app/decorators/module_overview_decorator.rb
+++ b/app/decorators/module_overview_decorator.rb
@@ -2,6 +2,22 @@
 # Call to action button logic
 #
 class ModuleOverviewDecorator < DelegateClass(ModuleProgress)
+  # @see LearningController#module_progress
+  # @return [String]
+  def description
+    if unvisited.size <= 20
+      I18n.t('my_learning.progress.remaining', num: unvisited.size)
+    else
+      I18n.t('my_learning.progress.viewed', num: visited.size)
+    end
+  end
+
+  # @see LearningController#module_progress
+  # @return [String]
+  def percentage
+    "#{(value * 100).round}%"
+  end
+
   # @return [Array<Symbol, <Training::Page, Training::Question, Training::Video>?] state locales key and target page
   def call_to_action
     if completed?

--- a/app/services/module_progress.rb
+++ b/app/services/module_progress.rb
@@ -119,8 +119,6 @@ protected
     (unvisited.first.id..unvisited.last.id).count != unvisited.map(&:id).count
   end
 
-private
-
   # @return [Array<Module::Content>]
   def visited
     mod.content.select { |item| visited?(item) }
@@ -130,6 +128,8 @@ private
   def unvisited
     mod.content.reject { |item| visited?(item) }
   end
+
+private
 
   # @param method [Symbol]
   # @param items [Array<Module::Content>]

--- a/app/views/learning/_card.html.slim
+++ b/app/views/learning/_card.html.slim
@@ -1,7 +1,20 @@
 .card
   .card-container
     = training_module_image(mod)
+
     h3.govuk-heading-s
       = govuk_link_to mod.card_title, training_module_path(mod.name), no_visited_state: true, class: 'card-link--header'
-    - if current
+
+    - if progress
       = link_to_retake_or_results(mod)
+
+      .card-progress-bar
+        .percentage
+          = t('my_learning.progress.percentage', num: progress.percentage)
+
+        .bar-settings
+          .bar-bg
+          .bar-progress style="width: #{progress.percentage}"
+            .bar-ball
+
+        .description= progress.description

--- a/app/views/learning/show.html.slim
+++ b/app/views/learning/show.html.slim
@@ -21,7 +21,7 @@
     - else
       .grid-container
         - current_user.course.current_modules.each do |mod|
-          = render 'card', mod: mod, current: true
+          = render 'card', mod: mod, progress: module_progress(mod)
 
 - if current_user.course.available_modules.any? || current_user.course.course_completed?
   hr.govuk-section-break.govuk-section-break--visible.govuk-section-break--l
@@ -31,7 +31,7 @@
       - if current_user.course.available_modules.any?
         .grid-container
           - current_user.course.available_modules.each do |mod|
-            = render 'card', mod: mod, current: false
+            = render 'card', mod: mod, progress: false
 
       - elsif current_user.course.course_completed?
         p You do not have any modules available.

--- a/config/application.rb
+++ b/config/application.rb
@@ -108,7 +108,7 @@ module EarlyYearsFoundationRecovery
 
     # @return [Boolean]
     def maintenance?
-      Types::Params::Bool[ENV.fetch('MAINTENANCE', true)]
+      Types::Params::Bool[ENV.fetch('MAINTENANCE', false)]
     end
 
     # @return [ActiveSupport::TimeWithZone]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,6 +272,10 @@ en:
   # /my-learning
   my_learning:
     title: My modules
+    progress:
+      percentage: "Your progress: %{num}"
+      viewed: You have read %{num} pages
+      remaining: Only %{num} pages remaining
 
   my_learning_log:
     title: Learning log

--- a/db/seeds/users.yml
+++ b/db/seeds/users.yml
@@ -18,4 +18,5 @@ completed@example.com:
   setting_type: Childminder as part of an agency
   role_type: Childminder
   early_years_emails: true
+  training_emails: true
   registration_complete: true

--- a/spec/lib/seed_snippets_spec.rb
+++ b/spec/lib/seed_snippets_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SeedSnippets do
   subject(:locales) { described_class.new.call }
 
   it 'converts all translations' do
-    expect(locales.count).to be 184
+    expect(locales.count).to be 187
   end
 
   it 'dot separated key -> Page::Resource#name' do

--- a/spec/system/my_learning_spec.rb
+++ b/spec/system/my_learning_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Learning activity' do
     end
 
     describe 'Available modules' do
-      it 'shows all published modules' do
+      it 'shows all released modules' do
         within '#available' do
           expect(page).to have_text 'Available modules'
           expect(page).to have_text 'First Training Module'
@@ -36,24 +36,13 @@ RSpec.describe 'Learning activity' do
     end
 
     describe 'Future modules' do
-      it 'shows unpublished modules' do
+      it 'shows unreleased modules' do
         within '#upcoming' do
           expect(page).to have_text 'Future modules in this course'
           expect(page).not_to have_text 'First Training Module'
           expect(page).not_to have_text 'Second Training Module'
           expect(page).not_to have_text 'Third Training Module'
 
-          # within '#bravo' do
-          #   expect(page).to have_text 'Second Training Module'
-          #   expect(page).to have_link 'View more information about this module', href: '/about-training#module-2-second-training-module'
-          # end
-
-          # within '#charlie' do
-          #   expect(page).to have_text 'Third Training Module'
-          #   expect(page).to have_link 'View more information about this module', href: '/about-training#module-3-third-training-module'
-          # end
-
-          # unpublished draft module
           within '#delta' do
             expect(page).to have_text 'Fourth Training Module'
             expect(page).not_to have_link 'View more information about this module', href: '/about-training#module-4-fourth-training-module'
@@ -69,7 +58,7 @@ RSpec.describe 'Learning activity' do
     end
   end
 
-  context 'when a user has started the first mandatory module' do
+  context 'when a user has started a module' do
     before do
       visit '/modules/alpha/content-pages/1-1'
       visit '/my-modules'
@@ -80,6 +69,9 @@ RSpec.describe 'Learning activity' do
         expect(page).to have_text 'Modules in progress'
         expect(page).to have_text 'First Training Module'
         expect(page).not_to have_text 'You have not started any modules.'
+
+        expect(page).to have_text 'You have read 1 pages' # FIXME: plurality
+        expect(page).to have_text 'Your progress: 3%'
       end
     end
   end


### PR DESCRIPTION
[ER-864]

<img width="1243" alt="Screenshot 2023-11-15 at 15 32 35" src="https://github.com/DFE-Digital/early-years-foundation-recovery/assets/3261/8a2ff382-067b-4f08-afd7-5a64e5eac194">

New resources using a `%{num}` variable:

- `my_learning.progress.percentage`
- `my_learning.progress.viewed`
- `my_learning.progress.remaining`

[ER-864]: https://dfedigital.atlassian.net/browse/ER-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ