### PR TITLE
ER-872 GovOne Banner

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,10 +9,6 @@ class HomeController < ApplicationController
     flash.now[:important] = t('banners.gov_one') unless Rails.application.gov_one_login?
   end
 
-  def gov_one
-    render 'devise/sessions/gov_one'
-  end
-
   def show
     render json: { status: 'HEALTHY' }, status: :ok
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,6 +5,12 @@ class HomeController < ApplicationController
 
   def index
     track('home_page')
+
+    flash.now[:important] = t('banners.gov_one') unless Rails.application.gov_one_login?
+  end
+
+  def gov_one
+    render 'devise/sessions/gov_one'
   end
 
   def show

--- a/app/views/layouts/_flash.html.slim
+++ b/app/views/layouts/_flash.html.slim
@@ -1,4 +1,4 @@
 .govuk-grid-row
   .govuk-grid-column-full
     - flash.each do |variant, message|
-      = govuk_notification_banner title_text: t("banners.#{variant}"), text: m(message), success: %w[important notice].include?(variant), classes: "govuk-notification-banner--#{variant}"
+      = govuk_notification_banner title_text: t("banners.#{variant}"), text: m(message), success: %w[notice].include?(variant), classes: "govuk-notification-banner--#{variant}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,7 +129,7 @@ en:
       ## Access to this website is changing
 
       From next month, you will require a GOV.UK One login account to access this website.
-      To find out about creating a GOV.UK One login account then [read this useful information page](/gov-one).
+      To find out about creating a GOV.UK One login account then [read this useful information page](https://www.gov.uk/using-your-gov-uk-one-login).
 
   # Training Modules -----------------------------------------------------------
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,8 +123,13 @@ en:
   banners:
     alert: Warning
     error: Error
-    important: Success
+    important: Important
     notice: Success
+    gov_one: |
+      ## Access to this website is changing
+
+      From next month, you will require a GOV.UK One login account to access this website.
+      To find out about creating a GOV.UK One login account then [read this useful information page](/gov-one).
 
   # Training Modules -----------------------------------------------------------
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,6 @@ Rails.application.routes.draw do
   root 'home#index'
   get 'health', to: 'home#show'
   get 'audit', to: 'home#audit'
-  get 'gov-one', to: 'home#gov_one' unless Rails.application.gov_one_login?
   get 'my-modules', to: 'learning#show' # @see User#course
 
   get '404', to: 'errors#not_found', via: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root 'home#index'
   get 'health', to: 'home#show'
   get 'audit', to: 'home#audit'
+  get 'gov-one', to: 'home#gov_one' unless Rails.application.gov_one_login?
   get 'my-modules', to: 'learning#show' # @see User#course
 
   get '404', to: 'errors#not_found', via: :all

--- a/spec/lib/seed_snippets_spec.rb
+++ b/spec/lib/seed_snippets_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SeedSnippets do
   subject(:locales) { described_class.new.call }
 
   it 'converts all translations' do
-    expect(locales.count).to be 204
+    expect(locales.count).to be 205
   end
 
   it 'dot separated key -> Page::Resource#name' do

--- a/spec/system/front_page_spec.rb
+++ b/spec/system/front_page_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe 'Front page' do
 
         # banner
         expect(page).not_to have_text 'Access to this website is changing'
-        expect(page).not_to have_link href: '/gov-one'
+        expect(page).not_to have_link href: 'https://www.gov.uk/using-your-gov-uk-one-login'
       else
         expect(page).not_to have_text 'Learn more and enrol'
         expect(page).not_to have_text 'Sign in to continue learning'
 
         # banner
         expect(page).to have_text 'Access to this website is changing'
-        expect(page).to have_link href: '/gov-one'
+        expect(page).to have_link href: 'https://www.gov.uk/using-your-gov-uk-one-login'
       end
     end
   end
@@ -37,14 +37,14 @@ RSpec.describe 'Front page' do
 
         # banner
         expect(page).not_to have_text 'Access to this website is changing'
-        expect(page).not_to have_link href: '/gov-one'
+        expect(page).not_to have_link href: 'https://www.gov.uk/using-your-gov-uk-one-login'
       else
         expect(page).to have_text 'Learn more and enrol'
         expect(page).to have_text 'Sign in to continue learning'
 
         # banner
         expect(page).to have_text 'Access to this website is changing'
-        expect(page).to have_link href: '/gov-one'
+        expect(page).to have_link href: 'https://www.gov.uk/using-your-gov-uk-one-login'
       end
     end
   end

--- a/spec/system/front_page_spec.rb
+++ b/spec/system/front_page_spec.rb
@@ -12,9 +12,17 @@ RSpec.describe 'Front page' do
       if Rails.application.gov_one_login?
         expect(page).not_to have_text 'Learn more about this training'
         expect(page).not_to have_text 'Start your training now'
+
+        # banner
+        expect(page).not_to have_text 'Access to this website is changing'
+        expect(page).not_to have_link href: '/gov-one'
       else
         expect(page).not_to have_text 'Learn more and enrol'
         expect(page).not_to have_text 'Sign in to continue learning'
+
+        # banner
+        expect(page).to have_text 'Access to this website is changing'
+        expect(page).to have_link href: '/gov-one'
       end
     end
   end
@@ -26,9 +34,17 @@ RSpec.describe 'Front page' do
       if Rails.application.gov_one_login?
         expect(page).to have_text 'Learn more about this training'
         expect(page).to have_text 'Start your training now'
+
+        # banner
+        expect(page).not_to have_text 'Access to this website is changing'
+        expect(page).not_to have_link href: '/gov-one'
       else
         expect(page).to have_text 'Learn more and enrol'
         expect(page).to have_text 'Sign in to continue learning'
+
+        # banner
+        expect(page).to have_text 'Access to this website is changing'
+        expect(page).to have_link href: '/gov-one'
       end
     end
   end


### PR DESCRIPTION
[ER-872] 

Add banner regarding the change to Gov One authentication. This changes a resource and adds a new one.

- `banners.important`: Important
- `banners.gov_one`: tbc

[ER-872]: https://dfedigital.atlassian.net/browse/ER-872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ