### PR TITLE
Quick CMS resource debugger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,13 +70,12 @@ DASHBOARD_UPDATE=y # optional upload activation for local dev
 DASHBOARD_UPDATE_INTERVAL=*/5 * * * *
 
 # Contentful
-CONTENTFUL=true
-# (overrides)
 CONTENTFUL_SPACE=
-CONTENTFUL_ENVIRONMENT=test # master, staging
 CONTENTFUL_MANAGEMENT_TOKEN=
 CONTENTFUL_DELIVERY_TOKEN=
 CONTENTFUL_PREVIEW_TOKEN=
+CONTENTFUL_ENVIRONMENT=test # master, staging
+CONTENTFUL_PREVIEW=true
 
 # Contentful DB migration flags
 DISABLE_USER_ANSWER=true

--- a/app/models/page/resource.rb
+++ b/app/models/page/resource.rb
@@ -18,4 +18,11 @@ class Page::Resource < ContentfulModel::Base
       find_by(name: name.to_s).first
     end
   end
+
+  # @return [Array<Page::Resource>]
+  def self.ordered
+    fetch_or_store to_key("#{name}.__method__") do
+      limit(1_000).order(:name).load.to_a
+    end
+  end
 end

--- a/lib/seed_snippets.rb
+++ b/lib/seed_snippets.rb
@@ -16,6 +16,11 @@ class SeedSnippets < SeedContentful
     end
   end
 
+  # @return [Array<String>]
+  def list
+    locales.map { |l| l[:name] }
+  end
+
 private
 
   # @param resource [Contentful::Management::DynamicEntry]

--- a/lib/tasks/cms.rake
+++ b/lib/tasks/cms.rake
@@ -102,5 +102,17 @@ namespace :eyfs do
         File.write(file_path, file_data)
       end
     end
+
+    desc 'Resource tally'
+    task resources: :environment do
+      cms_resources = Page::Resource.ordered.map(&:name)
+      require 'seed_snippets'
+      yaml_locales = SeedSnippets.new.list
+      tally = (yaml_locales - cms_resources).sort
+
+      puts "'#{Rails.application.config.contentful_environment}' is missing #{tally.count} resources:"
+      puts '------------------------------------'
+      tally.each { |r| puts r }
+    end
   end
 end

--- a/spec/models/page/resource_spec.rb
+++ b/spec/models/page/resource_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Page::Resource, type: :model do
+  describe '.by_name' do
+    specify do
+      expect(described_class.by_name('test.resource')).to be_a Page::Resource
+    end
+  end
+
+  describe '.ordered' do
+    specify do
+      expect(described_class.ordered).to be_one
+    end
+  end
+end

--- a/spec/models/page/resource_spec.rb
+++ b/spec/models/page/resource_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Page::Resource, type: :model do
   describe '.by_name' do
     specify do
-      expect(described_class.by_name('test.resource')).to be_a Page::Resource
+      expect(described_class.by_name('test.resource')).to be_a described_class
     end
   end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Page, type: :model do
+  describe '.by_name' do
+    specify do
+      expect(described_class.by_name('sitemap')).to be_a Page
+    end
+  end
+
+  describe '.footer' do
+    specify do
+      expect(described_class.footer.count).to be 5
+    end
+  end
+
+  describe '#title' do
+    specify do
+      expect(described_class.by_name('sitemap').title).to eq 'Sitemap'
+    end
+  end
+end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Page, type: :model do
   describe '.by_name' do
     specify do
-      expect(described_class.by_name('sitemap')).to be_a Page
+      expect(described_class.by_name('sitemap')).to be_a described_class
     end
   end
 

--- a/spec/system/account_page_spec.rb
+++ b/spec/system/account_page_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Account page', type: :system do
 
     if Rails.application.gov_one_login?
       expect(page).not_to have_link 'Change password'
-      expect(page).to have_content 'Changing your name on this account will not affect your Gov.UK One Login'
+      expect(page).to have_content 'Changing your name on this account will not affect your GOV.UK One Login'
     else
       expect(page).to have_link 'Change password'
     end


### PR DESCRIPTION
CMS resources will ideally have parity with I18n locales. Add a rake task to help identify gaps and bolster test coverage.