### PR TITLE
ER-899 Local Authority User active user update

### DIFF
--- a/app/models/data_analysis/local_authority_user.rb
+++ b/app/models/data_analysis/local_authority_user.rb
@@ -30,7 +30,7 @@ module DataAnalysis
 
       # @return [User::ActiveRecord_Relation]
       def public_beta_users
-        User.since_public_beta.with_local_authority.registration_complete
+        User.not_closed.since_public_beta.with_local_authority.registration_complete
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -27,6 +27,22 @@ FactoryBot.define do
       registration_complete { true }
     end
 
+    trait :closed do
+      named
+      setting_type_id { 'academy' }
+      setting_type { 'Academy' }
+      setting_type_other { nil }
+      role_type { 'Practitioner' }
+      role_type_other { nil }
+      local_authority { 'City of London' }
+      training_emails { true }
+      early_years_emails { false }
+      registration_complete { true }
+      closed_at { '2024-01-08 10:23:40.946267' }
+      closed_reason { 'other' }
+      closed_reason_custom { 'I did not find the training useful' }
+    end
+
     factory :gov_one_user do
       registered
       gov_one_id { 'urn:fdc:gov.uk:2022:23-random-alpha-numeric' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -28,16 +28,7 @@ FactoryBot.define do
     end
 
     trait :closed do
-      named
-      setting_type_id { 'academy' }
-      setting_type { 'Academy' }
-      setting_type_other { nil }
-      role_type { 'Practitioner' }
-      role_type_other { nil }
-      local_authority { 'City of London' }
-      training_emails { true }
-      early_years_emails { false }
-      registration_complete { true }
+      registered
       closed_at { '2024-01-08 10:23:40.946267' }
       closed_reason { 'other' }
       closed_reason_custom { 'I did not find the training useful' }

--- a/spec/models/data_analysis/local_authority_user_spec.rb
+++ b/spec/models/data_analysis/local_authority_user_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe DataAnalysis::LocalAuthorityUser do
     # Incomplete registration
     create :user, :named, local_authority: 'LA3'
 
+    # Closed account
+    create :user, :closed, local_authority: 'LA3'
+
     # Registered user
     create :user, :registered, local_authority: 'LA1'
     create :user, :registered, local_authority: 'LA1'


### PR DESCRIPTION
[ER-899](https://dfedigital.atlassian.net/browse/ER-899)
Update to ensure only active users are reported for local authority user

[ER-899]: https://dfedigital.atlassian.net/browse/ER-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ