### PR TITLE
ER-899 Update user count for Local Authority User

### DIFF
--- a/app/models/data_analysis/local_authority_user.rb
+++ b/app/models/data_analysis/local_authority_user.rb
@@ -30,7 +30,7 @@ module DataAnalysis
 
       # @return [User::ActiveRecord_Relation]
       def public_beta_users
-        User.not_closed.since_public_beta.with_local_authority.registration_complete
+        User.not_closed.with_local_authority.registration_complete
       end
     end
   end

--- a/app/models/data_analysis/user_overview.rb
+++ b/app/models/data_analysis/user_overview.rb
@@ -31,6 +31,8 @@ module DataAnalysis
           'Start Training Mail Recipients',
           'Continue Training Mail Recipients',
           'New Module Mail Recipients',
+          'Closed',
+          'Terms and Conditions Agreed',
         ]
       end
 
@@ -62,6 +64,8 @@ module DataAnalysis
           start_training_mail_recipients: StartTrainingMailJob.recipients.count,
           continue_training_mail_recipients: ContinueTrainingMailJob.recipients.count,
           new_module_mail_recipients: NewModuleMailJob.recipients.count,
+          closed: User.closed.count,
+          terms_and_conditions_agreed: terms_and_conditions_agreed_count,
         }]
       end
 
@@ -80,6 +84,11 @@ module DataAnalysis
       # @return [Integer]
       def without_notes_count
         User.not_closed.without_notes.count
+      end
+
+      # @return [Integer]
+      def terms_and_conditions_agreed_count
+        User.all.count { |u| u.terms_and_conditions_agreed_at.present? }
       end
 
       # @note Ahoy::Event.module_start.distinct.count(:user_id)

--- a/spec/models/data_analysis/user_overview_spec.rb
+++ b/spec/models/data_analysis/user_overview_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe DataAnalysis::UserOverview do
       'Start Training Mail Recipients',
       'Continue Training Mail Recipients',
       'New Module Mail Recipients',
+      'Closed',
+      'Terms and Conditions Agreed',
     ]
   end
 
@@ -60,6 +62,8 @@ RSpec.describe DataAnalysis::UserOverview do
         start_training_mail_recipients: 1,
         continue_training_mail_recipients: 0,
         new_module_mail_recipients: 6,
+        closed: 0,
+        terms_and_conditions_agreed: 6,
       },
     ]
   end


### PR DESCRIPTION
[ER-899](https://dfedigital.atlassian.net/browse/ER-899)
Local Authority User update to count all active users across all phases.

Closed and Terms and Conditions agreed counts have been added to User Overview to allow this to be checked