### PR TITLE
ER-924 Update wording for updated LA list

### DIFF
--- a/app/forms/registration/local_authority_form.rb
+++ b/app/forms/registration/local_authority_form.rb
@@ -8,7 +8,7 @@ module Registration
     def save
       return false unless valid?
 
-      user.update!(local_authority: local_authority)
+      user.update!(local_authority: local_authority.gsub(/\(.*?\)/, ''))
     end
   end
 end

--- a/data/local-authority.yml
+++ b/data/local-authority.yml
@@ -29,7 +29,7 @@
 - name: County Durham
 - name: Coventry
 - name: Croydon
-- name: Cumberland
+- name: Cumberland (previously Cumbria)
 - name: Darlington
 - name: Derby
 - name: Derbyshire
@@ -143,7 +143,7 @@
 - name: West Northamptonshire
 - name: West Sussex
 - name: Westminster
-- name: Westmorland and Furness
+- name: Westmorland and Furness (previously Cumbria)
 - name: Wigan
 - name: Wiltshire
 - name: Windsor and Maidenhead


### PR DESCRIPTION
[ER-924](https://dfedigital.atlassian.net.mcas.ms/browse/ER-924)

Wording has been updated for Cumberland and Westmorland and Furness to include information about the previous local authority for these LA's

The wording in the brackets is not included when this is saved

[ER-924]: https://dfedigital.atlassian.net/browse/ER-924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ