### PR TITLE
Fix failing LA spec following update to LA list

### DIFF
--- a/app/forms/registration/local_authority_form.rb
+++ b/app/forms/registration/local_authority_form.rb
@@ -8,7 +8,15 @@ module Registration
     def save
       return false unless valid?
 
-      user.update!(local_authority: local_authority.gsub(/\(.*?\)/, '').strip)
+      user.update!(local_authority: local_authority_clean)
+    end
+
+  private
+
+    # @see Trainee:Authority#persisted_name
+    # @return [String] remove old name suffix
+    def local_authority_clean
+      local_authority.gsub(/\(.*?\)/, '').strip
     end
   end
 end

--- a/app/forms/registration/local_authority_form.rb
+++ b/app/forms/registration/local_authority_form.rb
@@ -8,7 +8,7 @@ module Registration
     def save
       return false unless valid?
 
-      user.update!(local_authority: local_authority.gsub(/\(.*?\)/, ''))
+      user.update!(local_authority: local_authority.gsub(/\(.*?\)/, '').strip)
     end
   end
 end

--- a/app/models/trainee/authority.rb
+++ b/app/models/trainee/authority.rb
@@ -11,5 +11,13 @@ module Trainee
     def self.data
       YAML.load_file Rails.root.join('data/local-authority.yml')
     end
+
+    # @example
+    #   Sanitise LA name changes before persisting
+    #     "Cumberland (previously Cumbria)" => "Cumberland"
+    # @return [String]
+    def persisted_name
+      name.gsub(/\(.*?\)/, '').strip
+    end
   end
 end

--- a/spec/requests/registration/local_authorities_spec.rb
+++ b/spec/requests/registration/local_authorities_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Registration local authority', type: :request do
     end
 
     context 'with available option' do
-      let(:local_authority) { Trainee::Authority.all.sample.name }
+      let(:local_authority) { Trainee::Authority.all.sample.name.gsub(/\(.*?\)/, '').strip }
 
       it 'updates user' do
         expect { update_user }.to change { user.reload.local_authority }.to(local_authority)

--- a/spec/requests/registration/local_authorities_spec.rb
+++ b/spec/requests/registration/local_authorities_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Registration local authority', type: :request do
     end
 
     context 'with available option' do
-      let(:local_authority) { Trainee::Authority.all.sample.name.gsub(/\(.*?\)/, '').strip }
+      let(:local_authority) { Trainee::Authority.all.sample.persisted_name }
 
       it 'updates user' do
         expect { update_user }.to change { user.reload.local_authority }.to(local_authority)


### PR DESCRIPTION
This update is to fix the failing local authority spec following the LA list update (for [ER-924](https://dfedigital.atlassian.net.mcas.ms/browse/ER-924))

[ER-924]: https://dfedigital.atlassian.net/browse/ER-924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ