### PR TITLE
ER-927 Learning Check styling update

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -85,7 +85,7 @@ Hero layout
   }
 
   #assessment-results .govuk-notification-banner {
-    margin-bottom: govuk-spacing(8);
+    margin-bottom: govuk-spacing(4);
   }
 
   @include govuk-media-query($until: tablet) {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -85,7 +85,11 @@ Hero layout
   }
 
   #assessment-results .govuk-notification-banner {
-    margin-bottom: govuk-spacing(4);
+    margin-bottom: govuk-spacing(8);
+  }
+
+  #formative-results .govuk-notification-banner {
+      margin-bottom: govuk-spacing(4);
   }
 
   @include govuk-media-query($until: tablet) {

--- a/app/views/training/questions/show.html.slim
+++ b/app/views/training/questions/show.html.slim
@@ -9,12 +9,12 @@
 = form_with model: current_user_response, url: training_module_response_path(mod.name, content.name), method: :patch do |f|
 
   .govuk-grid-row
-    #assessment-results.govuk-grid-column-two-thirds-from-desktop
+    .govuk-grid-column-two-thirds-from-desktop
       = f.govuk_error_summary
       = render partial: content.to_partial_path, locals: { f: f }, object: current_user_response, as: :response
 
       - if content.formative_question? && current_user_response.responded?
-        = render 'assessment_banner'
+        #formative-results= render 'assessment_banner'
 
 
   .govuk-grid-row

--- a/app/views/training/questions/show.html.slim
+++ b/app/views/training/questions/show.html.slim
@@ -9,7 +9,7 @@
 = form_with model: current_user_response, url: training_module_response_path(mod.name, content.name), method: :patch do |f|
 
   .govuk-grid-row
-    .govuk-grid-column-two-thirds-from-desktop
+    #assessment-results.govuk-grid-column-two-thirds-from-desktop
       = f.govuk_error_summary
       = render partial: content.to_partial_path, locals: { f: f }, object: current_user_response, as: :response
 


### PR DESCRIPTION
[ER-927](https://dfedigital.atlassian.net.mcas.ms/browse/ER-927)

Updated margin-bottom to ensure there is spacing between the Learning Check and the HR. The margin-bottom for this is 20px. This is also applied to all the banners which have the assessment results styling here.



<img width="876" alt="Screenshot 2024-02-26 at 14 44 28" src="https://github.com/DFE-Digital/early-years-foundation-recovery/assets/78093815/457f9c80-6c8a-484a-a061-829d6e7b6562">


[ER-927]: https://dfedigital.atlassian.net/browse/ER-927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ