### PR TITLE
Next link logic

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -71,6 +71,12 @@ Rails/Validation:
     - 'app/models/course.rb'
     - 'app/models/training/module.rb'
 
+# Offense count: 1
+# This cop supports safe autocorrection (--autocorrect).
+Style/EmptyCaseCondition:
+  Exclude:
+    - 'app/decorators/next_page_decorator.rb'
+
 # Offense count: 2
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/IdenticalConditionalBranches:

--- a/app/decorators/next_page_decorator.rb
+++ b/app/decorators/next_page_decorator.rb
@@ -1,0 +1,106 @@
+# TODO: assessments controller #new can be removed
+#
+# Button or link labels to the next page
+# @see [LinkHelper#link_to_next]
+#
+class NextPageDecorator
+  extend Dry::Initializer
+
+  # @!attribute [r] user
+  #   @return [User]
+  option :user, Types.Instance(User), required: true
+  # @!attribute [r] mod
+  #   @return [Training::Module]
+  option :mod, Types::TrainingModule, required: true
+  # @!attribute [r] content
+  #   @return [Training::Page, Training::Question, Training::Video]
+  option :content, Types::TrainingContent, required: true
+  # @!attribute [r] assessment
+  #   @return [AssessmentProgress]
+  option :assessment, required: true
+
+  # @return [String]
+  def name
+    if content.interruption_page?
+      mod.content_start.name
+    else
+      content.next_item.name
+    end
+  end
+
+  # @see [Pagination]
+  # @return [String]
+  def text
+    case
+    when next?            then label[:next]
+    when missing?         then label[:missing]
+    when content.section? then label[:section]
+    when test_start?      then label[:start_test]
+    when test_finish?     then label[:finish_test]
+    when finish?          then label[:finish]
+    when save?            then label[:save_continue]
+    else
+      label[:next]
+    end
+  end
+
+  # @return [Boolean]
+  def disable_question_submission?
+    if content.formative_question?
+      answered?
+    elsif content.summative_question?
+      answered? && (Rails.application.migrated_answers? ? assessment.graded? : assessment.score.present?)
+    else
+      false
+    end
+  end
+
+private
+
+  # @return [Hash=>Symbol]
+  def label
+    I18n.t(:next_page)
+  end
+
+  # @return [Boolean]
+  def next?
+    content.interruption_page? || disable_question_submission?
+  end
+
+  # @return [Boolean]
+  def save?
+    content.notes? || content.summative_question?
+  end
+
+  # @return [Boolean]
+  def answered?
+    user.response_for(content).responded?
+  end
+
+  # @return [Boolean]
+  def finish?
+    content.next_item.certificate?
+  end
+
+  # @return [Boolean]
+  def test_start?
+    content.next_item.summative_question? &&
+      !content.summative_question? &&
+      !disable_question_submission?
+  end
+
+  # @return [Boolean]
+  def test_finish?
+    content.next_item.assessment_results? && !disable_question_submission?
+  end
+
+  # @return [Boolean]
+  def missing?
+    content.next_item.eql?(content) && wip?
+  end
+
+  # @return [Boolean]
+  def wip?
+    Rails.application.preview? || Rails.env.test?
+  end
+end

--- a/app/decorators/pagination_decorator.rb
+++ b/app/decorators/pagination_decorator.rb
@@ -6,7 +6,7 @@ class PaginationDecorator
 
   # @!attribute [r] content
   #   @return [Training::Page, Training::Question, Training::Video]
-  param :content, required: true
+  param :content, Types::TrainingContent, required: true
 
   # @return [String]
   def heading

--- a/app/forms/form_option.rb
+++ b/app/forms/form_option.rb
@@ -1,3 +1,4 @@
+#
 # Build an array of radio button binary options
 #
 # - opt_in.<field>

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -34,9 +34,7 @@ module LinkHelper
 
   # @return [String] next page (ends on certificate)
   def link_to_next
-    page = content.interruption_page? ? mod.content_start : content.next_item
-
-    govuk_button_link_to content.next_button_text, training_module_page_path(mod.name, page.name),
+    govuk_button_link_to next_page.text, training_module_page_path(mod.name, next_page.name),
                          id: 'next-action',
                          aria: { label: t('pagination.next') }
   end
@@ -73,5 +71,15 @@ module LinkHelper
     else
       govuk_link_to 'View previous test result', training_module_assessment_path(mod.name, mod.assessment_results_page.name), no_visited_state: true, class: 'card-link--retake'
     end
+  end
+
+  # @return [NextPageDecorator]
+  def next_page
+    NextPageDecorator.new(
+      user: current_user,
+      mod: mod,
+      content: content,
+      assessment: assessment_progress_service(mod),
+    )
   end
 end

--- a/app/models/training/content.rb
+++ b/app/models/training/content.rb
@@ -53,25 +53,6 @@ module Training
       heading
     end
 
-    # @return [String]
-    def next_button_text
-      if interruption_page?
-        'Next'
-      elsif next_item.eql?(self) && (Rails.application.preview? || Rails.env.test?)
-        'Next page has not been created'
-      elsif section?
-        'Start section'
-      elsif next_item.assessment_results?
-        'Finish test'
-      elsif next_item.summative_question? && !summative_question?
-        'Start test'
-      elsif next_item.certificate?
-        'Finish'
-      else
-        'Next'
-      end
-    end
-
     # @return [Boolean]
     def notes?
       (topic_intro? || text_page?) && notes

--- a/app/models/training/question.rb
+++ b/app/models/training/question.rb
@@ -102,15 +102,6 @@ module Training
       end
     end
 
-    # @return [String] decorator
-    def next_button_text
-      if summative_question?
-        last_assessment? ? 'Finish test' : 'Save and continue'
-      else
-        'Next'
-      end
-    end
-
   private
 
     # @return [Array<Array>]

--- a/app/services/assessment_progress.rb
+++ b/app/services/assessment_progress.rb
@@ -12,7 +12,7 @@ class AssessmentProgress
   option :user, Types.Instance(User), required: true
   # @!attribute [r] mod
   #   @return [Training::Module]
-  option :mod, Types.Instance(Training::Module), required: true
+  option :mod, Types::TrainingModule, required: true
 
   # @see Training::ResponsesController#redirect
   #

--- a/app/services/content_changes.rb
+++ b/app/services/content_changes.rb
@@ -1,3 +1,4 @@
+#
 # Content changes since the user's last visit, powered by Visit
 #
 class ContentChanges

--- a/app/services/module_progress.rb
+++ b/app/services/module_progress.rb
@@ -14,7 +14,7 @@ class ModuleProgress
   option :user, Types.Instance(User), required: true
   # @!attribute [r] mod
   #   @return [Training::Module]
-  option :mod, Types.Instance(Training::Module), required: true
+  option :mod, Types::TrainingModule, required: true
   # @!attribute [r] summative_assessment
   #   @return [AssessmentProgress]
   option :summative_assessment, default: proc { AssessmentProgress.new(user: user, mod: mod) }

--- a/app/views/notes/_form.html.slim
+++ b/app/views/notes/_form.html.slim
@@ -1,5 +1,4 @@
-
-= form_with(model: note, url: user_notes_path) do |form|
+= form_with(model: note, url: user_notes_path) do |f|
   .govuk-grid-row
     .govuk-grid-column-three-quarters
       .prompt
@@ -7,6 +6,11 @@
           .govuk-grid-column-one-quarter
             = icon(:pencil)
           .govuk-grid-column-three-quarters
+            = f.hidden_field :module_item_id, value: content.id
+            = f.hidden_field :title
+            = f.hidden_field :training_module
+            = f.hidden_field :name
+
             div class='govuk-!-margin-bottom-4'
               h2.govuk-heading-m Add to your learning log
 
@@ -16,20 +20,17 @@
                   ul
                     - note.errors.each do |error|
                       li= error.full_message
-              = form.govuk_text_area :body,
+              = f.govuk_text_area :body,
                 rows: 5,
+                autofocus: true,
                 form_group: { classes: 'small-screen-padding-right' },
                 label: { text: "Use this space to make notes on the reflection point. Do not enter any personal or sensitive information like children's names." } do
+
                 p.govuk_body
                   | All your notes will be added to your personal
                   =< govuk_link_to 'learning log', user_notes_path(anchor: content.parent.tab_anchor)
                   | .
-                p.govuk-body
-                  | Your notes
-              = form.hidden_field :module_item_id, value: content.id
-              = form.hidden_field :title
-              = form.hidden_field :training_module
-              = form.hidden_field :name
+                p.govuk-body Your notes
 
   .govuk-grid-row
     .govuk-grid-column-full
@@ -37,5 +38,5 @@
 
       .govuk-button-group
         = link_to_previous
-        = form.submit 'Save and continue', class: 'govuk-button', id: 'next-action'
+        = f.govuk_submit next_page.text
 

--- a/app/views/training/questions/show.html.slim
+++ b/app/views/training/questions/show.html.slim
@@ -25,8 +25,8 @@
       .govuk-button-group
         = link_to_previous
 
-        - unless content.formative_question? && current_user_response.responded?
-          = f.govuk_submit content.next_button_text
-        - else
+        - if next_page.disable_question_submission?
           = f.govuk_submit 'Responded', class: 'govuk-visually-hidden', disabled: true
           = link_to_next
+        - else
+          = f.govuk_submit next_page.text

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/config/initializers/types.rb
+++ b/config/initializers/types.rb
@@ -3,4 +3,7 @@ require 'dry-types'
 module Types
   include Dry.Types()
   include Dry::Core::Constants
+
+  TrainingModule = Instance(Training::Module)
+  TrainingContent = Instance(Training::Page) | Instance(Training::Question) | Instance(Training::Video)
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,6 +112,15 @@ en:
 
   na: Not applicable
 
+  next_page:
+    missing: Next page has not been created
+    section: Start section
+    next: Next
+    start_test: Start test
+    save_continue: Save and continue
+    finish_test: Finish test
+    finish: Finish
+
   links:
     save: Save
     continue: Continue

--- a/lib/content_seed.rb
+++ b/lib/content_seed.rb
@@ -10,7 +10,7 @@ class ContentSeed
   option :user, Types.Instance(User), required: true
   # @!attribute [r] mod
   #   @return [Training::Module]
-  option :mod, Types.Instance(Training::Module), required: true
+  option :mod, Types::TrainingModule, required: true
 
   # @return [Array<Array>]
   def call

--- a/lib/content_test_schema.rb
+++ b/lib/content_test_schema.rb
@@ -7,7 +7,7 @@ class ContentTestSchema
 
   # @!attribute [r] mod
   #   @return [Training::Module]
-  option :mod, Types.Instance(Training::Module), required: true
+  option :mod, Types::TrainingModule, required: true
 
   # @param pass [Boolean] default: true
   # @return [Array<Array>]

--- a/lib/migrate_training.rb
+++ b/lib/migrate_training.rb
@@ -25,7 +25,7 @@ class MigrateTraining
   # @return [Integer, nil]
   option :resume, Types::Integer, optional: true, reader: :private
 
-  # @return [?]
+  # @return [nil]
   def call
     ActiveRecord::Base.transaction do
       log "Migration started: #{Time.zone.now}"
@@ -106,7 +106,7 @@ private
     assessment
   end
 
-  # @param user_answer [UserAssessment]
+  # @param user_assessment [UserAssessment]
   # @return [Hash<Symbol=>Mixed>]
   def assessment_params(user_assessment)
     {

--- a/spec/decorators/next_page_decorator_spec.rb
+++ b/spec/decorators/next_page_decorator_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe NextPageDecorator do
+  subject(:decorator) do
+    described_class.new(user: user, mod: mod, content: content, assessment: assessment)
+  end
+
+  let(:user) { create :user, :registered }
+  let(:mod) { Training::Module.by_name(:alpha) }
+  let(:content) { mod.page_by_name('1-1-1') }
+  let(:assessment) { double }
+
+  it '#name' do
+    expect(decorator.name).to eq '1-1-2'
+  end
+
+  it '#text' do
+    expect(decorator.text).to eq 'Next'
+  end
+
+  it '#disable_question_submission?' do
+    expect(decorator.disable_question_submission?).to be false
+  end
+
+  context 'when adding to the learning log' do
+    let(:content) { mod.page_by_name('1-1-3-1') }
+
+    it '#text' do
+      expect(decorator.text).to eq 'Save and continue'
+    end
+  end
+
+  context 'when starting a section' do
+    let(:content) { mod.page_by_name('1-2') }
+
+    it '#text' do
+      expect(decorator.text).to eq 'Start section'
+    end
+  end
+
+  context 'when starting an assessment' do
+    let(:content) { mod.page_by_name('1-3-2') }
+
+    it '#text' do
+      expect(decorator.text).to eq 'Start test'
+    end
+  end
+
+  context 'when answering an assessment question' do
+    let(:content) { mod.page_by_name('1-3-2-1') }
+
+    it '#text' do
+      expect(decorator.text).to eq 'Save and continue'
+    end
+  end
+
+  context 'when finishing an assessment' do
+    let(:content) { mod.page_by_name('1-3-2-10') }
+
+    it '#text' do
+      expect(decorator.text).to eq 'Finish test'
+    end
+  end
+
+  context 'when reviewing a completed assessment' do
+    let(:content) { mod.page_by_name('1-3-2-1') }
+    let(:assessment) { instance_double(AssessmentProgress, graded?: true, score: 100) }
+
+    before do
+      if Rails.application.migrated_answers?
+        create :response,
+               user: user,
+               question_name: '1-3-2-1',
+               question_type: 'summative',
+               training_module: 'alpha',
+               answers: [1],
+               assessment: create(:assessment, user: user)
+      else
+        create :user_answer,
+               user: user,
+               name: '1-3-2-1',
+               module: 'alpha',
+               assessments_type: 'summative_assessment',
+               question: 'N/A for CMS only questions',
+               questionnaire_id: 0,
+               answer: [1]
+      end
+    end
+
+    it '#text' do
+      expect(decorator.text).to eq 'Next'
+    end
+
+    it '#disable_question_submission?' do
+      expect(decorator.disable_question_submission?).to be true
+    end
+  end
+
+  context 'when finishing a module' do
+    let(:content) { mod.page_by_name('1-3-3-5') }
+
+    it '#text' do
+      expect(decorator.text).to eq 'Finish'
+    end
+  end
+end

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 describe 'LinkHelper', type: :helper do
   let(:mod) { Training::Module.ordered.first }
 
+  let(:user) { create(:user, :registered) }
+
+  before do
+    allow(helper).to receive(:current_user).and_return(user)
+  end
+
   describe '#link_to_next' do
     subject(:link) { helper.link_to_next }
 

--- a/spec/lib/seed_snippets_spec.rb
+++ b/spec/lib/seed_snippets_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SeedSnippets do
   subject(:locales) { described_class.new.call }
 
   it 'converts all translations' do
-    expect(locales.count).to be 209
+    expect(locales.count).to be 216
   end
 
   it 'dot separated key -> Page::Resource#name' do


### PR DESCRIPTION
Work on feedback forms is increasing the complexity of navigating through pages and these changes will help improve functionality and testing.

Consolidates next link logic into a single location, introduces better type checks, and adds new CMS resources:


1. `next_page.missing` Next page has not been created
2. `next_page.section` Start section
3. `next_page.next` Next
4. `next_page.start_test` Start test
5. `next_page.save_continue` Save and continue
6. `next_page.finish_test` Finish test
7. `next_page.finish` Finish
