### PR TITLE
Refactor testing abstraction to help spec feedback form responses

### DIFF
--- a/spec/lib/content_test_schema_spec.rb
+++ b/spec/lib/content_test_schema_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe ContentTestSchema do
   let(:alpha) { Training::Module.by_name(:alpha) }
 
   let(:ast) do
-    YAML.load_file(Rails.root.join("spec/support/ast/#{fixture}.yml"))
-  end
-
-  before do
-    skip 'WIP' if Rails.application.migrated_answers?
+    if Rails.application.migrated_answers?
+      YAML.load_file(Rails.root.join("spec/support/ast/#{fixture}-response.yml"))
+    else
+      YAML.load_file(Rails.root.join("spec/support/ast/#{fixture}.yml"))
+    end
   end
 
   context 'when pass is true' do

--- a/spec/lib/content_test_schema_spec.rb
+++ b/spec/lib/content_test_schema_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ContentTestSchema do
     let(:fixture) { 'alpha-fail' }
 
     specify do
-      expect(schema.call(pass: false)).to eq ast
+      expect(schema.call(pass: false).compact).to eq ast
     end
   end
 end

--- a/spec/support/ast/alpha-fail-response.yml
+++ b/spec/support/ast/alpha-fail-response.yml
@@ -44,7 +44,7 @@
   :text: Question One - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-2-field
+      - response-answers-2-field
     - - :click_on
       - Next
     - - :click_on
@@ -63,7 +63,7 @@
   :text: Question Two - Select from following
   :inputs:
     - - :check
-      - user-answer-answers-2-field
+      - response-answers-2-field
     - - :click_on
       - Next
     - - :click_on
@@ -77,9 +77,9 @@
   :text: Question Three - Select from following
   :inputs:
     - - :check
-      - user-answer-answers-2-field
+      - response-answers-2-field
     - - :check
-      - user-answer-answers-4-field
+      - response-answers-4-field
     - - :click_on
       - Next
     - - :click_on
@@ -103,75 +103,75 @@
   :text: Question One - Select from following
   :inputs:
     - - :check
-      - user-answer-answers-2-field
+      - response-answers-2-field
     - - :check
-      - user-answer-answers-4-field
+      - response-answers-4-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-2
   :text: Question Two - Select from following
   :inputs:
     - - :check
-      - user-answer-answers-1-field
+      - response-answers-1-field
     - - :check
-      - user-answer-answers-4-field
+      - response-answers-4-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-3
   :text: Question Three - Select from following
   :inputs:
     - - :check
-      - user-answer-answers-1-field
+      - response-answers-1-field
     - - :check
-      - user-answer-answers-2-field
+      - response-answers-2-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-4
   :text: Question Four - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-1-field
+      - response-answers-1-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-5
   :text: Question Five - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-1-field
+      - response-answers-1-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-6
   :text: Question Six - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-1-field
+      - response-answers-1-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-7
   :text: Question Seven - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-1-field
+      - response-answers-1-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-8
   :text: Question Eight - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-1-field
+      - response-answers-1-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-9
   :text: Question Nine - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-1-field
+      - response-answers-1-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-10
   :text: Question Ten - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-1-field
+      - response-answers-1-field
     - - :click_on
       - Finish test

--- a/spec/support/ast/alpha-pass-response.yml
+++ b/spec/support/ast/alpha-pass-response.yml
@@ -44,7 +44,7 @@
   :text: Question One - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-2-field
+      - response-answers-1-field
     - - :click_on
       - Next
     - - :click_on
@@ -63,7 +63,9 @@
   :text: Question Two - Select from following
   :inputs:
     - - :check
-      - user-answer-answers-2-field
+      - response-answers-1-field
+    - - :check
+      - response-answers-3-field
     - - :click_on
       - Next
     - - :click_on
@@ -77,9 +79,9 @@
   :text: Question Three - Select from following
   :inputs:
     - - :check
-      - user-answer-answers-2-field
+      - response-answers-1-field
     - - :check
-      - user-answer-answers-4-field
+      - response-answers-3-field
     - - :click_on
       - Next
     - - :click_on
@@ -103,75 +105,121 @@
   :text: Question One - Select from following
   :inputs:
     - - :check
-      - user-answer-answers-2-field
+      - response-answers-1-field
     - - :check
-      - user-answer-answers-4-field
+      - response-answers-3-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-2
   :text: Question Two - Select from following
   :inputs:
     - - :check
-      - user-answer-answers-1-field
+      - response-answers-2-field
     - - :check
-      - user-answer-answers-4-field
+      - response-answers-3-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-3
   :text: Question Three - Select from following
   :inputs:
     - - :check
-      - user-answer-answers-1-field
+      - response-answers-3-field
     - - :check
-      - user-answer-answers-2-field
+      - response-answers-4-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-4
   :text: Question Four - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-1-field
+      - response-answers-3-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-5
   :text: Question Five - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-1-field
+      - response-answers-3-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-6
   :text: Question Six - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-1-field
+      - response-answers-3-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-7
   :text: Question Seven - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-1-field
+      - response-answers-3-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-8
   :text: Question Eight - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-1-field
+      - response-answers-3-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-9
   :text: Question Nine - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-1-field
+      - response-answers-3-field
     - - :click_on
       - Save and continue
 - :path: /modules/alpha/questionnaires/1-3-2-10
   :text: Question Ten - Select from following
   :inputs:
     - - :choose
-      - user-answer-answers-1-field
+      - response-answers-3-field
     - - :click_on
       - Finish test
+- :path: /modules/alpha/assessment-result/1-3-2-11
+  :text: Assessment results
+  :inputs:
+    - - :click_on
+      - Next
+- :path: /modules/alpha/content-pages/1-3-3
+  :text: Reflect on your learning
+  :inputs:
+    - - :click_on
+      - Next
+- :path: /modules/alpha/questionnaires/1-3-3-1
+  :text: Question One - Select from 1 to 5
+  :inputs:
+    - - :choose
+      - response-answers-5-field
+    - - :click_on
+      - Next
+- :path: /modules/alpha/questionnaires/1-3-3-2
+  :text: Question Two - Select from 1 to 5
+  :inputs:
+    - - :choose
+      - response-answers-5-field
+    - - :click_on
+      - Next
+- :path: /modules/alpha/questionnaires/1-3-3-3
+  :text: Question Three - Select from 1 to 5
+  :inputs:
+    - - :choose
+      - response-answers-5-field
+    - - :click_on
+      - Next
+- :path: /modules/alpha/questionnaires/1-3-3-4
+  :text: Question Four - Select from 1 to 5
+  :inputs:
+    - - :choose
+      - response-answers-5-field
+    - - :click_on
+      - Next
+- :path: /modules/alpha/content-pages/1-3-3-5
+  :text: Thank you
+  :inputs:
+    - - :click_on
+      - Finish
+- :path: /modules/alpha/content-pages/1-3-4
+  :text: Congratulations!
+  :inputs: []

--- a/spec/support/shared/with_automated_path.rb
+++ b/spec/support/shared/with_automated_path.rb
@@ -1,70 +1,36 @@
-# Dynamic AST schema which supports future changes to content
+# Defaults to dynamic schema using happy path for alpha
+# but loads a YAML fixture instead if provided
+#
+# @example
+#   Dynamic:
+#
+#     include_context 'with automated path'
+#     let(:mod) { <Training::Module> }
+#     let(:happy) { <Boolean> }
+#
+#   Static:
+#
+#     include_context 'with automated path'
+#     let(:fixture) { 'spec/support/ast/bespoke-module-journey.yml' }
+#
 RSpec.shared_context 'with automated path' do
-  include_context 'with progress'
-  include_context 'with user'
-
-  let(:mod) { alpha }
+  let(:mod) { Training::Module.by_name(:alpha) }
   let(:happy) { true }
+  # Or
+  let(:fixture) { nil }
 
   let(:schema) do
-    ContentTestSchema.new(mod: mod).call(pass: happy).compact
-  end
-
-  before do
-    visit "/modules/#{mod.name}/content-pages/what-to-expect"
-
-    schema.each do |content|
-      # puts content[:path]
-      content[:inputs].each { |args| send(*args) }
-    end
-  end
-end
-
-# Static file export of AST schema answered correctly
-RSpec.shared_context 'with alpha happy path' do
-  include_context 'with progress'
-  include_context 'with user'
-
-  let(:mod) { alpha }
-
-  let(:schema) do
-    if Rails.application.migrated_answers?
-      YAML.load_file Rails.root.join('spec/support/ast/alpha-pass-response.yml')
+    if fixture.present?
+      YAML.load_file Rails.root.join(fixture)
     else
-      YAML.load_file Rails.root.join('spec/support/ast/alpha-pass.yml')
+      ContentTestSchema.new(mod: mod).call(pass: happy).compact
     end
   end
 
   before do
-    visit '/modules/alpha/content-pages/what-to-expect'
+    visit schema.first[:path]
 
     schema.each do |content|
-      # puts content[:path]
-      content[:inputs].each { |args| send(*args) }
-    end
-  end
-end
-
-# Static file export of AST schema answered incorrectly
-RSpec.shared_context 'with alpha unhappy path' do
-  include_context 'with progress'
-  include_context 'with user'
-
-  let(:mod) { alpha }
-
-  let(:schema) do
-    if Rails.application.migrated_answers?
-      YAML.load_file Rails.root.join('spec/support/ast/alpha-fail-response.yml')
-    else
-      YAML.load_file Rails.root.join('spec/support/ast/alpha-fail.yml')
-    end
-  end
-
-  before do
-    visit '/modules/alpha/content-pages/what-to-expect'
-
-    schema.each do |content|
-      # puts content[:path]
       content[:inputs].each { |args| send(*args) }
     end
   end

--- a/spec/support/shared/with_automated_path.rb
+++ b/spec/support/shared/with_automated_path.rb
@@ -1,0 +1,71 @@
+# Dynamic AST schema which supports future changes to content
+RSpec.shared_context 'with automated path' do
+  include_context 'with progress'
+  include_context 'with user'
+
+  let(:mod) { alpha }
+  let(:happy) { true }
+
+  let(:schema) do
+    ContentTestSchema.new(mod: mod).call(pass: happy).compact
+  end
+
+  before do
+    visit "/modules/#{mod.name}/content-pages/what-to-expect"
+
+    schema.each do |content|
+      # puts content[:path]
+      content[:inputs].each { |args| send(*args) }
+    end
+  end
+end
+
+# Static file export of AST schema answered correctly
+RSpec.shared_context 'with alpha happy path' do
+  include_context 'with progress'
+  include_context 'with user'
+
+  let(:mod) { alpha }
+
+  let(:schema) do
+    if Rails.application.migrated_answers?
+      YAML.load_file Rails.root.join('spec/support/ast/alpha-pass-response.yml')
+    else
+      YAML.load_file Rails.root.join('spec/support/ast/alpha-pass.yml')
+    end
+  end
+
+  before do
+    visit '/modules/alpha/content-pages/what-to-expect'
+
+    schema.each do |content|
+      # puts content[:path]
+      content[:inputs].each { |args| send(*args) }
+    end
+  end
+end
+
+# Static file export of AST schema answered incorrectly
+RSpec.shared_context 'with alpha unhappy path' do
+  include_context 'with progress'
+  include_context 'with user'
+
+  let(:mod) { alpha }
+
+  let(:schema) do
+    if Rails.application.migrated_answers?
+      YAML.load_file Rails.root.join('spec/support/ast/alpha-fail-response.yml')
+    else
+      YAML.load_file Rails.root.join('spec/support/ast/alpha-fail.yml')
+    end
+  end
+
+  before do
+    visit '/modules/alpha/content-pages/what-to-expect'
+
+    schema.each do |content|
+      # puts content[:path]
+      content[:inputs].each { |args| send(*args) }
+    end
+  end
+end

--- a/spec/support/shared/with_events.rb
+++ b/spec/support/shared/with_events.rb
@@ -4,7 +4,7 @@ RSpec.shared_context 'with events' do
   let(:user2) { create(:user, :registered) }
 
   let(:events) do
-    Event.where(user_id: user.id).where_properties(training_module_id: module_name)
+    Event.where(user_id: user.id).where_properties(training_module_id: mod.name)
   end
 
   def create_event(user, name, time, training_module, id = nil)

--- a/spec/support/shared/with_progress.rb
+++ b/spec/support/shared/with_progress.rb
@@ -32,26 +32,6 @@ RSpec.shared_context 'with progress' do
   end
 
   # @param mod [Training::Module]
-  def start_confidence_check(mod)
-    view_pages_upto(mod, 'confidence_questionnaire')
-  end
-
-  # @param mod [Training::Module]
-  def start_summative_assessment(mod)
-    view_pages_upto(mod, 'summative_questionnaire')
-  end
-
-  # @param mod [Training::Module]
-  def view_pages_upto_formative_question(mod, count = 1)
-    view_pages_upto(mod, 'formative_questionnaire', count)
-  end
-
-  # @param mod [Training::Module]
-  def view_certificate_page(mod)
-    view_pages_upto(mod, 'certificate')
-  end
-
-  # @param mod [Training::Module]
   # @param duration [ActiveSupport::Duration]
   def complete_module(mod, duration = nil)
     view_pages_upto(mod, 'certificate')

--- a/spec/system/confidence_check_spec.rb
+++ b/spec/system/confidence_check_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Confidence check' do
   let(:first_question_path) { '/modules/alpha/questionnaires/1-3-3-1' }
 
   before do
-    start_confidence_check(alpha)
+    view_pages_upto alpha, 'confidence_questionnaire'
     visit first_question_path
   end
 

--- a/spec/system/event_log_spec.rb
+++ b/spec/system/event_log_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Event log' do
     end
 
     context 'when all questions are answered incorrectly' do
-      # include_context 'with alpha unhappy path'
+      # let(:fixture) { 'spec/support/ast/alpha-fail-response.yml' }
       let(:happy) { false }
 
       it 'tracks answers and failed attempt' do

--- a/spec/system/event_log_spec.rb
+++ b/spec/system/event_log_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'Event log' do
   include_context 'with events'
+  include_context 'with user'
   include_context 'with automated path'
-  # include_context 'with alpha happy path'
 
   describe 'confidence check' do
     context 'when viewing the first question' do

--- a/spec/system/formative_question_spec.rb
+++ b/spec/system/formative_question_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Formative question' do
   include_context 'with user'
 
   before do
-    view_pages_upto_formative_question(alpha)
+    view_pages_upto alpha, 'formative_questionnaire', 1
   end
 
   context 'when a user has visited each page up to and including a formative question' do

--- a/spec/system/module_overview_progress_spec.rb
+++ b/spec/system/module_overview_progress_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe 'Module overview page progress' do
 
   context 'when the last page of the first submodule is reached' do
     before do
-      view_pages_upto_formative_question(alpha)
+      view_pages_upto alpha, 'formative_questionnaire'
       visit '/modules/alpha'
     end
 
@@ -161,16 +161,11 @@ RSpec.describe 'Module overview page progress' do
   end
 
   context 'when the summative assessment is failed' do
-    before do
-      visit '/modules/alpha/content-pages/what-to-expect'
+    include_context 'with automated path'
 
-      # OPTIMIZE: the setup for this context leverages the AST schema which supports future changes to content
-      ContentTestSchema.new(mod: alpha).call(pass: false).compact.each do |content|
-        content[:inputs].each { |args| send(*args) }
-      end
+    let(:happy) { false }
 
-      visit '/modules/alpha'
-    end
+    before { visit '/modules/alpha' }
 
     specify { expect(page).to have_link 'Retake test' }
   end

--- a/spec/system/summative_assessment_spec.rb
+++ b/spec/system/summative_assessment_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Summative assessment', type: :system do
   let(:first_question_path) { '/modules/alpha/questionnaires/1-3-2-1' }
 
   before do
-    start_summative_assessment(alpha)
+    view_pages_upto alpha, 'summative_questionnaire'
   end
 
   describe 'intro' do
@@ -54,13 +54,10 @@ RSpec.describe 'Summative assessment', type: :system do
 
   describe 'results' do
     context 'when every question is answered correctly' do
+      # include_context 'with automated path'
+      include_context 'with alpha happy path'
+
       before do
-        visit '/modules/alpha/content-pages/what-to-expect'
-
-        ContentTestSchema.new(mod: alpha).call(pass: true).compact.each do |content|
-          content[:inputs].each { |args| send(*args) }
-        end
-
         visit '/modules/alpha/assessment-result/1-3-2-11'
       end
 
@@ -96,13 +93,9 @@ RSpec.describe 'Summative assessment', type: :system do
     end
 
     context 'when failed' do
-      before do
-        visit '/modules/alpha/content-pages/what-to-expect'
-
-        ContentTestSchema.new(mod: alpha).call(pass: false).compact.each do |content|
-          content[:inputs].each { |args| send(*args) }
-        end
-      end
+      # include_context 'with automated path'
+      # let(:happy) { false }
+      include_context 'with alpha unhappy path'
 
       it 'displays score with wrong answers' do
         expect(page).to have_content 'You scored 0%'

--- a/spec/system/summative_assessment_spec.rb
+++ b/spec/system/summative_assessment_spec.rb
@@ -54,8 +54,15 @@ RSpec.describe 'Summative assessment', type: :system do
 
   describe 'results' do
     context 'when every question is answered correctly' do
-      # include_context 'with automated path'
-      include_context 'with alpha happy path'
+      include_context 'with automated path'
+
+      let(:fixture) do
+        if Rails.application.migrated_answers?
+          'spec/support/ast/alpha-pass-response.yml'
+        else
+          'spec/support/ast/alpha-pass.yml'
+        end
+      end
 
       before do
         visit '/modules/alpha/assessment-result/1-3-2-11'
@@ -93,9 +100,15 @@ RSpec.describe 'Summative assessment', type: :system do
     end
 
     context 'when failed' do
-      # include_context 'with automated path'
-      # let(:happy) { false }
-      include_context 'with alpha unhappy path'
+      include_context 'with automated path'
+
+      let(:fixture) do
+        if Rails.application.migrated_answers?
+          'spec/support/ast/alpha-fail-response.yml'
+        else
+          'spec/support/ast/alpha-fail.yml'
+        end
+      end
 
       it 'displays score with wrong answers' do
         expect(page).to have_content 'You scored 0%'


### PR DESCRIPTION
Make it easier to test using YAML (supporting responses after migration) and handle the more nuanced journeys, for example, the new feedback questions.