### PR TITLE
ER-954 Timeout post SSO

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -51,8 +51,8 @@ module EarlyYearsFoundationRecovery
     # Timeout
     # user_timeout_warning_minutes and user_timeout_modal_visible value combined must be lower than user_timeout_minutes
     config.unlock_in_minutes            = ENV.fetch('UNLOCK_IN_MINUTES', '120').to_i
-    config.user_timeout_minutes         = ENV.fetch('TIMEOUT_MINUTES', '25').to_i
-    config.user_timeout_warning_minutes = ENV.fetch('TIMEOUT_WARNING_MINUTES', '20').to_i
+    config.user_timeout_minutes         = ENV.fetch('TIMEOUT_MINUTES', '60').to_i
+    config.user_timeout_warning_minutes = ENV.fetch('TIMEOUT_WARNING_MINUTES', '55').to_i
     config.user_timeout_modal_visible   = ENV.fetch('TIMEOUT_MODAL_VISIBLE', '5').to_i
 
     # Contentful

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe 'Application configuration' do
 
   describe 'time out' do
     it 'sets interval in minutes' do
-      expect(config.user_timeout_minutes).to eq 25
-      expect(config.user_timeout_warning_minutes).to eq 20
+      expect(config.user_timeout_minutes).to eq 60
+      expect(config.user_timeout_warning_minutes).to eq 55
       expect(config.user_timeout_modal_visible).to eq 5
     end
   end

--- a/spec/requests/timeout_warning_spec.rb
+++ b/spec/requests/timeout_warning_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe 'Session timeout warning', type: :request do
       # lag may have lowered the counter when the assertion is made
       it 'reports seconds before timeout' do
         expect(response).to have_http_status(:success)
-        expect(response.body.to_i).to be_within(1).of(1500) # ~25*60
+        expect(response.body.to_i).to be_within(1).of(3600) # ~60*60
       end
 
       it 'decreases over time' do
         travel_to 1.minute.from_now
         get check_session_timeout_path
-        expect(response.body.to_i).to be_within(1).of(1440)
+        expect(response.body.to_i).to be_within(1).of(3540) # ~59*60
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe 'Session timeout warning', type: :request do
 
       it 'extends current session' do
         expect(response).to have_http_status(:success)
-        expect(response.body.to_i).to be_within(1).of(1500) # ~25*60
+        expect(response.body.to_i).to be_within(1).of(3600) # ~59*60
       end
     end
 


### PR DESCRIPTION
[ER-954]

Update timeout minutes to 60 to match SSO timeout length

[ER-954]: https://dfedigital.atlassian.net/browse/ER-954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ