### PR TITLE
Revert "Bump grover from 1.1.7 to 1.1.9 (#1262)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,7 +259,7 @@ GEM
     govuk_notify_rails (2.2.0)
       notifications-ruby-client (~> 5.1)
       rails (>= 4.1.0)
-    grover (1.1.9)
+    grover (1.1.7)
       combine_pdf (~> 1.0)
       nokogiri (~> 1.0)
     hashie (5.0.0)


### PR DESCRIPTION
This reverts commit 58842bb11d528bcc042f13d8489e6d07afeb0f17.

This PR is to check if downloading pdf's is resolved by reverting this Grover dependency bump