### PR TITLE
Attempt to fix Grover

### DIFF
--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -5,6 +5,7 @@ Grover.configure do |config|
   config.options = {
     executable_path: '/usr/bin/chromium-browser',
     launch_args: [
+      '--disable-gpu',
       '--disable-dev-shm-usage',
       '--font-render-hinting=none',
     ],


### PR DESCRIPTION
We are currently experiencing timeout issues in Grover when a user attempts to view their certificate at the end of a module. This fix attempts to resolve this. This not currently being reported as an issue on the live service, but this behaviour can be seen in lower environments.

This solution has been recommended in the Grover issues discussion.