### PR TITLE
EYCDTK-63 Add refresh to before_action if refresh is present

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   before_action :set_analytics_tracking_id,
                 :set_hotjar_site_id,
                 :prepare_cms
+  before_action :handle_refresh
 
   helper_method :current_user,
                 :debug?
@@ -95,5 +96,13 @@ private
     return true if bot?
 
     super
+  end
+
+  def handle_refresh
+    # Check if the `refresh` parameter is present
+    if params[:refresh]
+      # Perform a page reload or any other logic you need
+      redirect_to request.path, status: :found # Reload the page without the `refresh` parameter
+    end
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -99,7 +99,7 @@ private
       elsif !resource.email_preferences_complete?
         static_path('email-preferences')
       else
-        my_modules_path
+        my_modules_path(refresh: true)
       end
     else
       edit_registration_terms_and_conditions_path

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationController, type: :controller do
+  controller do
+    # Add an index action for testing purposes
+    def index
+      render plain: 'Test page'
+    end
+  end
+
   describe '#guest' do
     subject(:guest) { controller.send(:guest) }
 
@@ -33,6 +40,25 @@ RSpec.describe ApplicationController, type: :controller do
         expect(guest).to be_a Guest
         expect(guest.visit_token).to eq cookie_token
       end
+    end
+  end
+
+  describe 'GET #index with refresh param' do
+    it 'redirects and removes the refresh param' do
+      # Simulate a request with the refresh parameter
+      get :index, params: { refresh: true }
+
+      # Check that the response is a redirect
+      expect(response).to have_http_status(:found)
+
+      # Check that it redirects to the correct path
+      expect(response).to redirect_to('/anonymous')
+
+      # Simulate the follow-up request after the redirect
+      get :index
+
+      # Ensure that the refresh parameter is not in the final request
+      expect(request.query_parameters[:refresh]).to be_nil
     end
   end
 end

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
 
     it 'redirects to /my-modules' do
       expect(session[:id_token]).to eq id_token
-      expect(response).to redirect_to my_modules_path
+      expect(response).to redirect_to my_modules_path(refresh: true)
     end
   end
 
@@ -62,7 +62,7 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
 
     it 'redirects to /my-modules' do
       expect(session[:id_token]).to eq id_token
-      expect(response).to redirect_to my_modules_path
+      expect(response).to redirect_to my_modules_path(refresh: true)
     end
   end
 


### PR DESCRIPTION
Added a before_action to application controller if a refresh parameter is present so that we can ensure the redirect to my_modules isn't interrupted.