### PR TITLE
EYCDTK-120-add-logging-to-omniauthcallback-methods

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -6,24 +6,24 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def openid_connect
     if params['error'].present?
       Rails.logger.error("Authentication error: #{params['error']}, #{params['error_description']}")
-      return error_redirect
+      return error_redirect('Params errors present')
     end
 
-    return error_redirect unless session_params? && valid_params?
+    return error_redirect('Session_params & Valid_params error') unless session_params? && valid_params?
 
     auth_service = GovOneAuthService.new(code: params['code'])
     tokens_response = auth_service.tokens
-    return error_redirect unless valid_tokens?(tokens_response)
+    return error_redirect('No valid_tokens') unless valid_tokens?(tokens_response)
 
     id_token = auth_service.decode_id_token(tokens_response['id_token'])[0]
-    return error_redirect unless valid_id_token?(id_token)
+    return error_redirect('No valid_id_token') unless valid_id_token?(id_token)
 
     session[:id_token] = tokens_response['id_token']
     gov_one_id = id_token['sub']
 
     user_info_response = auth_service.user_info(tokens_response['access_token'])
     email = user_info_response['email']
-    return error_redirect unless valid_user_info?(user_info_response, gov_one_id)
+    return error_redirect('No valid_user_info') unless valid_user_info?(user_info_response, gov_one_id)
 
     gov_user = User.find_or_create_from_gov_one(email: email, gov_one_id: gov_one_id)
 
@@ -71,11 +71,13 @@ private
   end
 
   # @return [nil]
-  def error_redirect
+  def error_redirect(msg = 'default message')
     return if user_signed_in?
 
     flash[:alert] = 'There was a problem signing in. Please try again.'
     redirect_to root_path
+  rescue StandardError => e
+    Rails.logger.error("Error redirect: #{e.message} - #{msg}")
   end
 
   # @return [nil]

--- a/app/services/gov_one_auth_service.rb
+++ b/app/services/gov_one_auth_service.rb
@@ -67,6 +67,8 @@ class GovOneAuthService
     jwk = JWT::JWK.new(key_params)
 
     JWT.decode(token, jwk.public_key, true, { verify_iat: true, algorithm: 'ES256' })
+  rescue StandardError => e
+    Rails.logger.error "GovOneAuthService.decode_id_token: #{e.message}"
   end
 
   # @param address [String]
@@ -76,6 +78,8 @@ class GovOneAuthService
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     [uri, http]
+  rescue StandardError => e
+    Rails.logger.error "GovOneAuthService.build_http: #{e.message}"
   end
 
 private
@@ -87,6 +91,8 @@ private
       uri, http = build_http(ENDPOINTS[:jwks])
       response = http.request(Net::HTTP::Get.new(uri.path))
       JSON.parse(response.body)
+    rescue StandardError => e
+      Rails.logger.error "GovOneAuthService.jwks: #{e.message}"
     end
   end
 


### PR DESCRIPTION
Add rescues in the omniauth_callbacks_controller and gov_one_auth_service so that we can have a better quality of error logs to help define the log-in issue