### PR TITLE
EYCDTK-227-remove-redundant-code-in-omniauthcallbackkcontroller

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -74,8 +74,6 @@ private
 
   # @return [nil]
   def error_redirect(msg = 'default message')
-    return if user_signed_in?
-
     flash[:alert] = 'There was a problem signing in. Please try again.'
     redirect_to root_path
   rescue StandardError => e


### PR DESCRIPTION
As per cacthup with ben, this line is no longer needed due to:  https://github.com/DFE-Digital/early-years-foundation-recovery/pull/1387