### PR TITLE
Dependency updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,7 +291,7 @@ GEM
       activesupport (>= 5.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.9.1)
+    json (2.10.1)
     json-jwt (1.16.6)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -301,7 +301,7 @@ GEM
       faraday-follow_redirects
     jwt (2.8.2)
       base64
-    language_server-protocol (3.17.0.3)
+    language_server-protocol (3.17.0.4)
     logger (1.6.5)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -371,7 +371,7 @@ GEM
     os (1.1.4)
     pagy (9.3.3)
     parallel (1.26.3)
-    parser (3.3.6.0)
+    parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
     pg (1.5.8)
@@ -492,7 +492,7 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.1)
-    rubocop (1.69.2)
+    rubocop (1.70.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -508,8 +508,8 @@ GEM
       rubocop (~> 1.41)
     rubocop-factory_bot (2.26.1)
       rubocop (~> 1.61)
-    rubocop-govuk (5.0.7)
-      rubocop (= 1.69.2)
+    rubocop-govuk (5.0.8)
+      rubocop (= 1.70.0)
       rubocop-ast (= 1.37.0)
       rubocop-capybara (= 2.21.0)
       rubocop-rails (= 2.28.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,7 +247,7 @@ GEM
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (>= 6, < 10)
       view_component (>= 3.18, < 3.22)
-    govuk_design_system_formbuilder (5.4.1)
+    govuk_design_system_formbuilder (5.8.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -321,7 +321,7 @@ GEM
     multi_json (1.15.0)
     net-http (0.4.1)
       uri
-    net-imap (0.5.5)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,7 +317,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
-    msgpack (1.7.5)
+    msgpack (1.8.0)
     multi_json (1.15.0)
     net-http (0.4.1)
       uri
@@ -699,4 +699,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.5.11
+   2.6.3


### PR DESCRIPTION
- Update `govuk_design_system_formbuilder`
- Update `net-imap` for a security update
- Update various dependencies including `msgpack` and `bundler`