### PR TITLE
Update Rack to 3.1.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,7 +403,7 @@ GEM
       que (>= 0.14, < 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.1.9)
+    rack (3.1.10)
     rack-mini-profiler (3.3.1)
       rack (>= 1.2.0)
     rack-oauth2 (2.2.1)


### PR DESCRIPTION
Update Rack to 3.1.10 to address [this issue](https://github.com/DFE-Digital/early-years-foundation-recovery/security/dependabot/123)