### PR TITLE
Update factory_bot_rails to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,10 +183,10 @@ GEM
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
-    factory_bot (6.4.6)
-      activesupport (>= 5.0.0)
-    factory_bot_rails (6.4.3)
-      factory_bot (~> 6.4)
+    factory_bot (6.5.1)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.4.4)
+      factory_bot (~> 6.5)
       railties (>= 5.0.0)
     faker (3.4.2)
       i18n (>= 1.8.11, < 2)
@@ -302,7 +302,7 @@ GEM
     jwt (2.8.2)
       base64
     language_server-protocol (3.17.0.4)
-    logger (1.6.5)
+    logger (1.6.6)
     loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -403,7 +403,7 @@ GEM
       que (>= 0.14, < 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.1.9)
+    rack (3.1.10)
     rack-mini-profiler (3.3.1)
       rack (>= 1.2.0)
     rack-oauth2 (2.2.1)
@@ -569,7 +569,7 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
-    stringio (3.1.2)
+    stringio (3.1.3)
     swd (2.0.3)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
@@ -621,7 +621,7 @@ GEM
       backports (>= 3.18)
       rainbow
       yard
-    zeitwerk (2.7.1)
+    zeitwerk (2.7.2)
 
 PLATFORMS
   aarch64-linux-musl


### PR DESCRIPTION
This dependency update is to resolve deprecation warnings