### PR TITLE
Update focus to false in notes _form 

### DIFF
--- a/app/views/notes/_form.html.slim
+++ b/app/views/notes/_form.html.slim
@@ -22,7 +22,7 @@
                       li= error.full_message
               = f.govuk_text_area :body,
                 rows: 5,
-                autofocus: true,
+                autofocus: false,
                 form_group: { classes: 'small-screen-padding-right' },
                 label: { text: "Use this space to make notes on the reflection point. Do not enter any personal or sensitive information like children's names." } do
 


### PR DESCRIPTION
Update focus to false in notes form so that screenreaders autofocus to the log when doing a module

https://dfedigital.atlassian.net/jira/software/projects/EYCDTK/boards/251?selectedIssue=EYCDTK-396