### PR TITLE
BV - Add logging for queries over 5 seconds

### DIFF
--- a/terraform-azure/terraform-azure-database/main.tf
+++ b/terraform-azure/terraform-azure-database/main.tf
@@ -41,6 +41,14 @@ resource "azurerm_postgresql_flexible_server_configuration" "psqlfs_config" {
   value     = "CITEXT,FUZZYSTRMATCH,PGCRYPTO,PLPGSQL,UUID-OSSP"
 }
 
+resource "azurerm_postgresql_flexible_server_configuration" "log_min_duration_statement" {
+  name      = "log_min_duration_statement"
+  server_id = azurerm_postgresql_flexible_server.psqlfs.id
+  # To enable: this is in milliseconds, update this to a positive value in milliseconds to enable this logging
+  # To disable: update this to -1
+  value = 5000
+}
+
 # Create Database
 resource "azurerm_postgresql_flexible_server_database" "psqldb" {
   name      = "${var.resource_name_prefix}-${random_pet.name.id}-psqldb"


### PR DESCRIPTION
Add logging for queries over 5 seconds

https://techcommunity.microsoft.com/blog/adforpostgresql/enable-slow-query-logging-in-azure-database-for-postgresql/3639626 https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration https://github.com/search?q=azurerm_postgresql_flexible_server_configuration+log_min_duration_statement&type=code

Add terraform to set server parameter of log_min_duration_statement to 5 seconds (5000 ms). To disable set to -1.