### PR TITLE
Accessibility Audit - Labels do not match accessibility name

### DIFF
--- a/app/views/notes/_form.html.slim
+++ b/app/views/notes/_form.html.slim
@@ -24,8 +24,9 @@
                 rows: 5,
                 autofocus: false,
                 form_group: { classes: 'small-screen-padding-right' },
-                label: { text: "Use this space to make notes on the reflection point. Do not enter any personal or sensitive information like children's names." } do
+                label: { text: "Add to your learning log", hidden: true } do
 
+                p.govuk_body Use this space to make notes on the reflection point. Do not enter any personal or sensitive information like children's names.
                 p.govuk_body
                   | All your notes will be added to your personal
                   =< govuk_link_to 'learning log', user_notes_path(anchor: content.parent.tab_anchor)


### PR DESCRIPTION
Make label the same as heading for wcag 2.2. compliance, make it visually hidden so that it isn't redundantly repeating for sighted users.

https://dfedigital.atlassian.net/jira/software/projects/EYCDTK/boards/251?selectedIssue=EYCDTK-404