### PR TITLE
Revert "Bump tar-fs from 3.0.8 to 3.0.9 in the npm_and_yarn group"

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2945,8 +2945,8 @@ __metadata:
   linkType: hard
 
 "tar-fs@npm:^3.0.8":
-  version: 3.0.9
-  resolution: "tar-fs@npm:3.0.9"
+  version: 3.0.8
+  resolution: "tar-fs@npm:3.0.8"
   dependencies:
     bare-fs: "npm:^4.0.1"
     bare-path: "npm:^3.0.0"
@@ -2957,7 +2957,7 @@ __metadata:
       optional: true
     bare-path:
       optional: true
-  checksum: 00e194ef36ced339000099c3cb5205fcd9636a531158d73e0fc1ca056fbcf8dcf39a398cbc71f030bbf938d4f477f47e2913c6e37e9c007bad31e0768a120590
+  checksum: fdcd1c66dc5e2cad5544ffe7eab9a470b419290b22300c344688df51bf06127963da07a1e3ae23cae80851cd9f60149e80b38e56485dd7a14aea701241ac2f81
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts DFE-Digital/early-years-foundation-recovery#1505