### PR TITLE
Update section count so that it ignores feedback as a section

### DIFF
--- a/app/decorators/pagination_decorator.rb
+++ b/app/decorators/pagination_decorator.rb
@@ -44,6 +44,9 @@ private
 
   # @return [Integer]
   def section_total
-    content.parent.content_sections.size
+    content.parent.content_sections.count do |(_, content_items)|
+      first_item = content_items.first
+      !first_item.feedback_question?
+    end
   end
 end

--- a/spec/decorators/feedback_pagination_decorator_spec.rb
+++ b/spec/decorators/feedback_pagination_decorator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FeedbackPaginationDecorator do
   end
 
   it '#section_numbers' do
-    expect(decorator.section_numbers).to eq 'Section 4 of 5'
+    expect(decorator.section_numbers).to eq 'Section 4 of 4'
   end
 
   it '#page_numbers' do

--- a/spec/decorators/module_debug_decorator_spec.rb
+++ b/spec/decorators/module_debug_decorator_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ModuleDebugDecorator do
       expect(output.second).to eq [
         '1st',
         'false',
-        'Section 1 of 5',
+        'Section 1 of 4',
         '25%',
         '1',
         '0',
@@ -42,7 +42,7 @@ RSpec.describe ModuleDebugDecorator do
       expect(output.third).to eq [
         '2nd',
         'false',
-        'Section 1 of 5',
+        'Section 1 of 4',
         '50%',
         '1',
         '1',

--- a/spec/decorators/pagination_decorator_spec.rb
+++ b/spec/decorators/pagination_decorator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PaginationDecorator do
   end
 
   it '#section_numbers' do
-    expect(decorator.section_numbers).to eq 'Section 1 of 5'
+    expect(decorator.section_numbers).to eq 'Section 1 of 4'
   end
 
   it '#page_numbers' do

--- a/spec/system/certificate_spec.rb
+++ b/spec/system/certificate_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Certificate' do
 
   context 'when module is not completed' do
     before do
-      visit '/modules/alpha/content-pages/1-3-4'
+      visit '/modules/bravo/content-pages/1-3-4'
     end
 
     it 'does not show completion date' do
@@ -26,8 +26,8 @@ RSpec.describe 'Certificate' do
   context 'when module is completed' do
     before do
       travel_to Time.zone.parse('2022-06-30') do
-        complete_module(alpha)
-        visit '/modules/alpha/content-pages/1-3-4'
+        complete_module(bravo)
+        visit '/modules/bravo/content-pages/1-3-4'
       end
     end
 


### PR DESCRIPTION
Update section count to ensure that a section is not a feedback page. If it is a feedback page it would therefore be excluded from the list
Before:
<img width="942" height="187" alt="Screenshot 2025-07-22 at 11 12 30" src="https://github.com/user-attachments/assets/e36e1833-60c8-4bc5-aba6-24760b58f870" />

After:
<img width="1051" height="356" alt="Screenshot 2025-07-22 at 11 12 09" src="https://github.com/user-attachments/assets/3662ef4b-c485-4033-a128-83cc15f69809" />

