### PR TITLE
DTK-534 - progress spoken twice

### DIFF
--- a/app/views/learning/_card.html.slim
+++ b/app/views/learning/_card.html.slim
@@ -16,7 +16,7 @@
         .percentage
           = t('my_learning.progress.percentage', num: progress.percentage)
 
-        .bar-settings
+        .bar-settings aria-hidden="true"
           .bar-bg
           .bar-progress style="width: #{progress.percentage}"
             .bar-ball


### PR DESCRIPTION
Fixes issue - when using a screen reader, there are some issues with the progress bar being read twice