### PR TITLE
Eycdtk 482 setting type to free type has no effect 

### DIFF
--- a/app/forms/registration/setting_type_other_form.rb
+++ b/app/forms/registration/setting_type_other_form.rb
@@ -12,6 +12,7 @@ module Registration
         setting_type: 'other',
         setting_type_id: 'other',
         setting_type_other: setting_type_other,
+        role_type: I18n.t(:na),
         local_authority: I18n.t(:na),
       )
     end


### PR DESCRIPTION
Bring the two setting type forms in to line so that they both update role type to not applicable, this avoids the specific bug for any users with broken data