### PR TITLE
Update module_progress event so it uses time 

### DIFF
--- a/app/services/module_progress.rb
+++ b/app/services/module_progress.rb
@@ -129,12 +129,18 @@ private
 
   # @return [Event::ActiveRecord_AssociationRelation]
   # @note This method is used to fetch events for the current module.
+
   def module_page_events
-    @module_page_events ||= if @events_by_module_name
-                              @events_by_module_name[mod.name] || []
-                            else
-                              user.events.where_properties(training_module_id: mod.name)
-                            end
+    @module_page_events ||= begin
+      events = if @events_by_module_name
+                 @events_by_module_name[mod.name] || []
+               else
+                 user.events.where_properties(training_module_id: mod.name)
+               end
+
+      # Ensure they're in chronological order
+      events.sort_by { |e| e.time || Time.zone.at(0) }
+    end
   end
 
   # @param key [String] module_start, module_complete

--- a/spec/services/module_progress_spec.rb
+++ b/spec/services/module_progress_spec.rb
@@ -97,4 +97,28 @@ RSpec.describe ModuleProgress do
       end
     end
   end
+
+  describe '#module_page_events' do
+    let(:user_module_events) do
+      [
+        # Event with no time — should be treated as earliest (Time.at(0))
+        EventStub.new('page_view', { 'training_module_id' => 'alpha', 'id' => '2-1' }, nil),
+
+        # Event with an older timestamp
+        EventStub.new('page_view', { 'training_module_id' => 'alpha', 'id' => '1-1' }, now - 5.minutes),
+
+        # Event with the most recent timestamp
+        EventStub.new('page_view', { 'training_module_id' => 'alpha', 'id' => '3-1' }, now - 1.minute),
+      ]
+    end
+
+    it 'returns events sorted by time, with events missing time treated as earliest' do
+      # The expected order is:
+      # 1. Event with nil time ('2-1') - sorted to the front by Time.at(0)
+      # 2. Event with older timestamp ('1-1')
+      # 3. Event with most recent timestamp ('3-1')
+      sorted_ids = progress.send(:module_page_events).map { |e| e.properties['id'] }
+      expect(sorted_ids).to eq(%w[2-1 1-1 3-1])
+    end
+  end
 end


### PR DESCRIPTION
Sort the module_progress events by time so that when milestone method uses the .last function we are confident that the last is chronologically correct.