### PR TITLE
EYCDTK-556 Contentful publish issue

### DIFF
--- a/app/controllers/release_controller.rb
+++ b/app/controllers/release_controller.rb
@@ -21,7 +21,6 @@ class ReleaseController < WebhookController
   def update
     Rails.logger.info('[ReleaseController#update] Clearing module cache before updating release')
     Training::Module.cache.clear
-    Resource.reset_cache_key!
     Page.reset_cache_key!
 
     release = Release.create!(

--- a/app/controllers/release_controller.rb
+++ b/app/controllers/release_controller.rb
@@ -2,7 +2,6 @@ class ReleaseController < WebhookController
   def new
     Rails.logger.info('[ReleaseController#new] Clearing module cache before creating new release')
     Training::Module.cache.clear
-    Resource.reset_cache_key!
     Page.reset_cache_key!
 
     new_release = Release.create!(

--- a/spec/controllers/release_controller_spec.rb
+++ b/spec/controllers/release_controller_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe ReleaseController, type: :controller do
     stub_const('Resource', Class.new do
       def self.reset_cache_key!; end
     end)
-    allow(Resource).to receive(:reset_cache_key!)
     allow(Page).to receive(:reset_cache_key!)
 
     # stub background jobs


### PR DESCRIPTION
Remove reference to resetting resource cache key - as it is inaccessible due to its folder structure and is automatically reset as a child of 'page' and therefore redundant.

https://dfedigital.atlassian.net/browse/EYCDTK-566

This should fix the 500 errors we've been seeing in contentful and sentry.