### PR TITLE
Fix - docker buildx version pinned to 0.31.1

### DIFF
--- a/.github/workflows/azure-deploy-dev.yml
+++ b/.github/workflows/azure-deploy-dev.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.13.1
+          version: v0.31.1
 
       # Login to the container registry
       - name: Login to Github Container Registry

--- a/.github/workflows/azure-deploy-prod.yml
+++ b/.github/workflows/azure-deploy-prod.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.9.1
+          version: v0.31.1
 
       # Login to the container registry
       - name: Login to Github Container Registry

--- a/.github/workflows/azure-deploy-review.yml
+++ b/.github/workflows/azure-deploy-review.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.9.1
+          version: v0.31.1
 
       # Login to the container registry
       - name: Login to Github Container Registry

--- a/.github/workflows/azure-deploy-stage.yml
+++ b/.github/workflows/azure-deploy-stage.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.9.1
+          version: v0.31.1
 
       # Login to the container registry
       - name: Login to Github Container Registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
   merge_group:
   pull_request:
     paths-ignore:
-      - '.github/workflows/*'
-      - '!.github/workflows/ci.yml'
       - '**/*.md'
       - .docker*
       - .env.example

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -35,7 +35,7 @@
         - name: Set up Docker Buildx
           uses: docker/setup-buildx-action@v3
           with:
-            version: v0.9.1
+            version: v0.31.1
 
         # Login to the container registry
         - name: Login to Github Container Registry


### PR DESCRIPTION
Related issue https://github.com/actions/runner-images/issues/13474



https://docs.docker.com/engine/release-notes/29/#2900

> The daemon now requires API version v1.44 or later (Docker v25.0+).