### PR TITLE
EYCDTK-1237/Exports-more-changes

### DIFF
--- a/app/models/concerns/to_csv.rb
+++ b/app/models/concerns/to_csv.rb
@@ -39,7 +39,7 @@ module ToCsv
           dashboard.find_each(batch_size: batch_size) do |record|
             csv << decorator.call(record.dashboard_row).values
             batch_num += 1
-            Rails.logger.info("[EXPORT] #{name}.to_csv batch #{batch_num * batch_size}") if (batch_num % 10).zero?
+            Rails.logger.info("[EXPORT] #{name}.to_csv batch #{batch_num}") if (batch_num % 10).zero?
           end
         end
       end

--- a/app/models/data_analysis/user_module_completion.rb
+++ b/app/models/data_analysis/user_module_completion.rb
@@ -13,13 +13,15 @@ module DataAnalysis
       end
 
       # @return [Array<Hash>]
+
       def dashboard
+        registration_complete_user_ids = User.registration_complete.pluck(:id)
         Training::Module.ordered.reject(&:draft?).map do |mod|
-          completed_count = module_count(mod.name)
+          completed_count = UserModuleProgress.completed.where(module_name: mod.name, user_id: registration_complete_user_ids).count
           {
             module_name: mod.name,
             completed_count: completed_count,
-            completed_percentage: (completed_count / User.registration_complete.count.to_f),
+            completed_percentage: (completed_count / registration_complete_user_ids.size.to_f),
           }
         end
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -554,5 +554,12 @@ private
   end
 
   # Eager load user_module_progress for dashboard exports
-  scope :dashboard, -> { not_closed.includes(:user_module_progress) }
+  scope :dashboard, lambda {
+    not_closed.includes(
+      :user_module_progress,
+      :events,
+      :visits,
+      :responses,
+    )
+  }
 end

--- a/config/initializers/que.rb
+++ b/config/initializers/que.rb
@@ -19,3 +19,5 @@ Que.error_notifier = proc do |error, job|
     Sentry.capture_exception(error)
   end
 end
+
+Que.logger = Rails.logger


### PR DESCRIPTION
Final updates including:

- Update for Que Logger initialiser to set for rails loggers. This should ensure the logging of the dashboardjob (and all jobs) is output to azure logs. Currently it ends up silenced because it is running as a background process.
- A fix to the log output in the to_csv method, this was accidentally multiplying the number by batch_size meaning batch number was off by a multiple of 1000
- A refactor for UserModuleCompletion.to_csv so that we pass moduleprogress selects off to the Database and not in ruby memory. Previously this export took ~1 hour
- Added additional associations to the dashboard scope in users.csv. This is the problem export taking approx 4 hours.

