### PR TITLE
Eycdtk/131 8/security header misconfigs

### DIFF
--- a/adr/0028-content-security-policy-hardening.md
+++ b/adr/0028-content-security-policy-hardening.md
@@ -1,0 +1,59 @@
+# Harden Content Security Policy and Introduce Controlled Rollout Mode
+
+* Status: accepted
+
+## Context and Problem Statement
+
+An ITHC finding (5.1.3: Content-Security Policy Misconfigurations) identified that the
+application CSP allowed `unsafe-inline` for scripts and styles, used broad/wildcard
+allow-lists, and permitted overly broad connection targets. This weakened confidentiality
+and integrity protections by increasing the impact of script injection and data exfiltration.
+
+The report recommendations require:
+
+- removing `unsafe-inline`/`unsafe-eval`
+- using nonce/hash-based controls
+- setting strict explicit directives (including `default-src 'none'`)
+- preferring exact host allow-lists
+- enabling mixed-content protections
+- using report-only first, then enforcing
+
+## Decision Drivers
+
+- Address ITHC 5.1.3 with measurable CSP hardening
+- Reduce XSS and exfiltration blast radius
+- Preserve production stability during rollout
+- Keep an operational fallback without code redeploy
+
+## Considered Options
+
+1. Keep existing CSP and rely on other controls.
+2. Enforce strict CSP immediately in all environments with no fallback.
+3. Harden CSP and keep a controlled report-only toggle for rollout/incident response.
+
+## Decision Outcome
+
+Chosen option: 3.
+
+We harden CSP by removing permissive directives and adopting nonce-based controls,
+including explicit `default-src 'none'`, explicit source directives, and mixed-content
+protections (`upgrade-insecure-requests` and `block-all-mixed-content`).
+
+To support safe rollout and operational response, we retain `CSP_REPORT_ONLY` as an
+environment toggle:
+
+- `CSP_REPORT_ONLY=true`: report-only mode (evaluate and report, do not block)
+- `CSP_REPORT_ONLY=false`: enforce mode (evaluate and block)
+
+Expected steady state is enforced CSP in production (`CSP_REPORT_ONLY=false`).
+Report-only in production is temporary and only for rollout diagnostics or break-glass
+incident mitigation.
+
+## Consequences
+
+- Security posture improves against inline/script injection abuse paths.
+- Some frontend refactoring is required to remove inline styles/scripts that conflict
+  with stricter policy.
+- Operations gain a reversible runtime switch for controlled rollout and recovery.
+- Teams must treat production report-only as temporary and explicitly track reversion
+  to enforcement.

--- a/adr/ADR.md
+++ b/adr/ADR.md
@@ -34,6 +34,7 @@ This log lists the architectural decisions for EYFS Recovery
 * [ADR-0025-2](0025-application-insights/0025-2-opentelemetry_deployment_sidecar.md) - Embedded OpenTelemetry Collector
 * [ADR-0026](0026-cookie-same-site-policy.md) - Cookie `SameSite` policy
 * [ADR-0027](0027-start-training-reminder-timing.md) - Reduce start training reminder delay to one week
+* [ADR-0028](0028-content-security-policy-hardening.md) - Harden Content Security Policy and Introduce Controlled Rollout Mode
 
 <!-- adrlogstop -->
 

--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -5,11 +5,11 @@
 .menu-btn {
   display: none;
 
-  &:checked ~ .dfe-vertical-nav {
+  &:checked~.dfe-vertical-nav {
     display: block;
   }
 
-  &:not(:checked) ~ .dfe-vertical-nav {
+  &:not(:checked)~.dfe-vertical-nav {
     display: none;
 
     @include govuk-media-query($from: tablet) {

--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -109,12 +109,26 @@ label.menu-icon {
   &-panel {
     flex: 100%;
     padding: 1.5em;
-    background-size: cover;
-    background-position: center;
 
     @include govuk-media-query($from: tablet) {
       flex: 50%;
       padding: 3em;
     }
   }
+
+  &-panel--thumbnail {
+    min-height: 150px;
+    display: flex;
+    align-items: stretch;
+    justify-content: stretch;
+    padding: 0;
+  }
+}
+
+.about-module-box-thumbnail {
+  width: 100%;
+  height: 100%;
+  min-height: 150px;
+  object-fit: cover;
+  display: block;
 }

--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -78,10 +78,13 @@
   background-color: govuk-colour('light-grey');
   border-bottom: 3px solid govuk-colour('dark-blue');
 
-  &:hover, &:focus-within {
-    background-color:  $govuk-link-hover-colour;
+  &:hover,
+  &:focus-within {
+    background-color: $govuk-link-hover-colour;
 
-    a, .percentage, .description {
+    a,
+    .percentage,
+    .description {
       color: govuk-colour('white');
     }
 
@@ -114,10 +117,10 @@
     max-width: 300px;
   }
 
-.govuk-tag--ey {
-  width: min-content;
-  margin: govuk-spacing(1) 0;
-}
+  .govuk-tag--ey {
+    width: min-content;
+    margin: govuk-spacing(1) 0;
+  }
 
   &-container {
     display: flex;
@@ -158,10 +161,13 @@
 
   }
 
-  &:hover, &:focus-within {
-    background-color:  $govuk-link-hover-colour;
+  &:hover,
+  &:focus-within {
+    background-color: $govuk-link-hover-colour;
 
-    a, .percentage, .description {
+    a,
+    .percentage,
+    .description {
       color: govuk-colour('white');
     }
 
@@ -198,7 +204,8 @@
     outline: 3px solid govuk-colour('yellow');
   }
 
-  &-link--retake, &-link--header {
+  &-link--retake,
+  &-link--header {
     &:focus {
       @include govuk-focused-text;
       background-color: $govuk-focus-colour;
@@ -217,11 +224,11 @@
     position: relative;
     z-index: 2;
   }
-  
+
   &-link--header {
     text-decoration: none;
     color: govuk-colour('blue');
-    
+
     // TODO: document what this is doing
     &::after {
       position: absolute;

--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -12,12 +12,22 @@
   border-radius: 4px;
 }
 
+@for $i from 0 through 100 {
+  .bar-progress--#{$i} {
+    width: percentage($i / 100);
+  }
+}
+
 .bar-ball {
   width: 17px;
   height: 17px;
   border-radius: 9px;
   top: -4px;
   right: 0;
+}
+
+.note-form-errors {
+  color: govuk-colour('red');
 }
 
 // ================================================================================

--- a/app/assets/stylesheets/section-bar.scss
+++ b/app/assets/stylesheets/section-bar.scss
@@ -32,3 +32,14 @@ p#progress-pages {
     background-color: $govuk-success-colour;
   }
 }
+
+@for $i from 0 through 100 {
+  .section-progress--#{$i} {
+    width: percentage($i / 100);
+  }
+}
+
+.debug_dump--error {
+  background-color: govuk-colour('red');
+  color: govuk-colour('white');
+}

--- a/app/views/about/show.html.slim
+++ b/app/views/about/show.html.slim
@@ -23,7 +23,9 @@
       .about-module-box-panel
         p.govuk-body-l
           = mod.description
-      .about-module-box-panel style="min-height: 150px; background-image: url(#{mod.thumbnail_url})"
+      .about-module-box-panel.about-module-box-panel--thumbnail
+        - if mod.thumbnail_url.present?
+          = image_tag mod.thumbnail_url, alt: '', class: 'about-module-box-thumbnail', loading: 'lazy'
 
     = m('about.summary', outcomes: mod.outcomes, criteria: mod.criteria)
     = render 'enrol'

--- a/app/views/layouts/_analytics_header.html.slim
+++ b/app/views/layouts/_analytics_header.html.slim
@@ -1,19 +1,19 @@
 - if track_analytics?
-  javascript:
-    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer', "#{@tracking_id}");
+  = javascript_tag nonce: true do
+    | (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    | new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    | j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    | 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    | })(window,document,'script','dataLayer', "#{@tracking_id}");
 
   - if @clarity_tracking_id.present?
-    javascript:
-      (function(c,l,a,r,i,t,y){
-        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-      })(window, document, "clarity", "script", "#{@clarity_tracking_id}");
-
-      if (window.clarity) {
-        window.clarity('consent');
-      }
+    = javascript_tag nonce: true do
+      | (function(c,l,a,r,i,t,y){
+      |   c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+      |   t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+      |   y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      | })(window, document, "clarity", "script", "#{@clarity_tracking_id}");
+      |
+      | if (window.clarity) {
+      |   window.clarity('consent');
+      | }

--- a/app/views/layouts/_head.html.slim
+++ b/app/views/layouts/_head.html.slim
@@ -8,6 +8,7 @@ title= yield :page_title
 = tag.meta property: 'og:image', content: image_path('eycdt_opengraph.png')
 
 = csrf_meta_tags
+= csp_meta_tag
 
 = favicon_link_tag image_path('dfe_favicon.ico')
 

--- a/app/views/learning/_card.html.slim
+++ b/app/views/learning/_card.html.slim
@@ -20,7 +20,7 @@
 
         .bar-settings
           .bar-bg
-          .bar-progress style="width: #{progress.percentage}"
+          .bar-progress class="bar-progress--#{progress.percentage.to_i.clamp(0, 100)}"
             .bar-ball
 
       - if show_progress_description && progress.description.present?

--- a/app/views/notes/_form.html.slim
+++ b/app/views/notes/_form.html.slim
@@ -18,7 +18,7 @@
               h2.govuk-heading-m Add to your learning log
 
               - if note.errors.any?
-                div style='color: red'
+                .note-form-errors
                   h2= "#{pluralize(note.errors.count, 'error')} prohibited this note from being saved:"
                   ul
                     - note.errors.each do |error|

--- a/app/views/training/modules/_editor_tools.html.slim
+++ b/app/views/training/modules/_editor_tools.html.slim
@@ -1,5 +1,5 @@
 - if mod.data.debug?
-  pre.debug_dump style='background-color: red; color: white'
+  pre.debug_dump.debug_dump--error
     h2 CONTENT SUMMARY
     ol
       - mod.data.errors.each do |hint|

--- a/app/views/training/modules/_section_bar.html.slim
+++ b/app/views/training/modules/_section_bar.html.slim
@@ -6,7 +6,7 @@
   p#progress-pages= section_bar.page_numbers
 
   #progress-inactive
-    #progress-active style="width: #{section_bar.percentage}"
+    #progress-active class="section-progress--#{section_bar.percentage.to_i.clamp(0, 100)}"
 
 - if Rails.application.preview?
   = link_to_cms

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,10 +13,6 @@
 #
 # Add URLs in order to import images or javascript from another domain
 #
-GOVUK_DOMAINS = %w[
-  *.education.gov.uk
-].freeze
-
 GOOGLE_ANALYTICS_DOMAINS = %w[
   www.google-analytics.com
   ssl.google-analytics.com
@@ -51,65 +47,64 @@ Rails.application.config.content_security_policy do |policy|
   # @see https://www.contentful.com/developers/docs/tutorials/general/live-preview/#set-up-live-preview
   policy.frame_ancestors :self, 'https://app.contentful.com'
 
-  policy.default_src :self,
-                     :https,
-                     *GOVUK_DOMAINS
+  policy.default_src :none
+  policy.base_uri    :self
+  policy.form_action :self
+
   policy.font_src    :self,
-                     :https,
-                     *GOVUK_DOMAINS,
                      *GOOGLE_STATIC_DOMAINS,
                      :data
+
   policy.frame_src   :self,
                      *GOOGLE_ANALYTICS_DOMAINS,
                      *OPTIMIZE_DOMAINS
+
   policy.img_src     :self,
-                     *GOVUK_DOMAINS,
                      *GOOGLE_ANALYTICS_DOMAINS, # Tracking pixels
                      *OPTIMIZE_DOMAINS,
                      *CLARITY_DOMAINS,
-                     '*.ctfassets.net',
+                     'images.ctfassets.net',
                      'github.com', # eyrecovery-dev.azurewebsites.net
                      :data # Base64 encoded images
 
+  policy.media_src   :self,
+                     'player.vimeo.com',
+                     'i.vimeocdn.com'
+
   policy.object_src  :none
+
   policy.script_src  :self,
-                     *GOVUK_DOMAINS,
                      *GOOGLE_ANALYTICS_DOMAINS,
                      *GOOGLE_STATIC_DOMAINS,
                      *OPTIMIZE_DOMAINS,
-                     *CLARITY_DOMAINS,
-                     # Allow all inline scripts until we can conclusively
-                     # document all the inline scripts we use,
-                     # and there's a better way to filter out junk reports
-                     :unsafe_inline
+                     *CLARITY_DOMAINS
+
   policy.style_src   :self,
-                     *GOVUK_DOMAINS,
                      *GOOGLE_STATIC_DOMAINS,
-                     *OPTIMIZE_DOMAINS,
-                     :unsafe_inline
+                     *OPTIMIZE_DOMAINS
 
   webpack_dev_server = %w[http://localhost:3035 ws://localhost:3035] if Rails.env.development?
 
   policy.connect_src :self,
-                     :https,
-                     :wss,
-                     *GOVUK_DOMAINS,
                      *GOOGLE_ANALYTICS_DOMAINS,
                      *CLARITY_DOMAINS,
                      *webpack_dev_server.to_a
+
+  policy.upgrade_insecure_requests
+  policy.block_all_mixed_content
 end
 
 # If you are using UJS then enable automatic nonce generation
 #
-# Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
 #
 # Set the nonce only to specific directives
 #
-# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
+Rails.application.config.content_security_policy_nonce_directives = %w[script-src style-src]
 #
 # Report CSP violations to a specified URI
 # For further information see the following documentation
 #
 # - {https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only}
 #
-# Rails.application.config.content_security_policy_report_only = true
+Rails.application.config.content_security_policy_report_only = ENV.fetch('CSP_REPORT_ONLY', (!Rails.env.production?).to_s) == 'true'


### PR DESCRIPTION
Hardened CSP defaults and explicit directives (including default-src 'none')
Removed unsafe-inline from script/style directives
Enabled nonce-based CSP and applied nonces to inline analytics scripts
Added CSP meta tag in layout for nonce-aware rendering
Replaced inline style attributes with class-based styling so strict style policy can be enforced
Added mixed-content protections:
upgrade-insecure-requests
block-all-mixed-content
Added report-only rollout toggle via CSP_REPORT_ONLY