### PR TITLE
Update WAF policy exclusions to use RequestArgValues

### DIFF
--- a/terraform-azure/terraform-azure-web/appgateway.tf
+++ b/terraform-azure/terraform-azure-web/appgateway.tf
@@ -33,7 +33,7 @@ resource "azurerm_web_application_firewall_policy" "agw_wafp" {
 
     # Keep only the two exclusions you already know are free-text user input
     exclusion {
-      match_variable          = "RequestArgNames"
+      match_variable          = "RequestArgValues"
       selector                = "note[body]"
       selector_match_operator = "Equals"
     }
@@ -46,7 +46,7 @@ resource "azurerm_web_application_firewall_policy" "agw_wafp" {
 
     # Additional confirmed request parameters used in learning and feedback flows.
     exclusion {
-      match_variable          = "RequestArgNames"
+      match_variable          = "RequestArgValues"
       selector                = "response[text_input]"
       selector_match_operator = "Equals"
     }


### PR DESCRIPTION
Update WAF policy exclusions to use RequestArgValues in stead of names:

RequestArgNames only affects checks on the argument name itself, for example note[body].
That name is static and harmless, so excluding it usually does almost nothing for learning-log false positives.

RequestArgValues affects checks on the submitted text value for that argument.
That is where OWASP rules get triggered by normal free text, so this is the exclusion type that actually reduces those blocks.

In plain terms:

Names: ignore the label.
Values: ignore the content under that label.