### PR TITLE
Fix intermittent learning-log submission failures

### DIFF
--- a/app/controllers/training/notes_controller.rb
+++ b/app/controllers/training/notes_controller.rb
@@ -16,8 +16,10 @@ class Training::NotesController < ApplicationController
   def create
     nav_keys = %i[next_page_name next_page_module module_item_id]
     attrs = note_params.except(*nav_keys)
-    note_instance = existing_note || Note.new(attrs)
-    if note_instance.save
+    # NB: assign attrs even when a note already exists, otherwise re-saving a page
+    # silently discards the user's edited body and redirects as if it succeeded.
+    note_instance = existing_note || Note.new
+    if note_instance.update(attrs)
       track('user_note_created')
       redirect_to next_page_path
     else
@@ -86,7 +88,7 @@ private
   # @return [Hash]
   def tracking_properties
     {
-      length: note_params[:body].length,
+      length: note_params[:body].to_s.length,
       **note_params.except(:body, :module_item_id, :user),
     }
   end

--- a/terraform-azure/terraform-azure-web/appgateway.tf
+++ b/terraform-azure/terraform-azure-web/appgateway.tf
@@ -1,3 +1,25 @@
+locals {
+  # User-supplied free-text form fields. These are prose typed by users
+  # (learning-log notes, feedback answers, names, custom "other" answers) and
+  # routinely contain apostrophes, angle brackets and SQL-ish words that trip the
+  # CRS XSS (941) and SQLi (942) rule groups, causing intermittent 403s.
+  #
+  # We exclude the WHOLE 941/942 groups for these args rather than picking off
+  # individual rule IDs: Rails parameter-binds and HTML-escapes these values, so
+  # treating them as non-injectable is safe, and new free-text fields only need a
+  # one-line addition here instead of another round of WAF whack-a-mole.
+  waf_free_text_args = [
+    "note[body]",                 # learning log
+    "note[title]",                # server-set, but kept for parity
+    "response[text_input]",       # feedback / question free text
+    "user[first_name]",           # registration — apostrophe surnames
+    "user[last_name]",            # registration — apostrophe surnames
+    "user[setting_type_other]",   # registration — custom setting
+    "user[role_type_other]",      # registration — custom role
+    "user[closed_reason_custom]", # account closure reason
+  ]
+}
+
 resource "azurerm_web_application_firewall_policy" "agw_wafp" {
   count = var.environment != "development" ? 1 : 0
 
@@ -31,52 +53,26 @@ resource "azurerm_web_application_firewall_policy" "agw_wafp" {
       selector_match_operator = "Equals"
     }
 
-    # Keep only the two exclusions you already know are free-text user input
-    exclusion {
-      match_variable          = "RequestArgValues"
-      selector                = "note[body]"
-      selector_match_operator = "Equals"
+    # Free-text user input: exclude the whole XSS (941) and SQLi (942) rule groups
+    # for every prose field. See local.waf_free_text_args for the field list.
+    dynamic "exclusion" {
+      for_each = local.waf_free_text_args
+      content {
+        match_variable          = "RequestArgValues"
+        selector                = exclusion.value
+        selector_match_operator = "Equals"
 
-      excluded_rule_set {
-        type    = "OWASP"
-        version = "3.2"
+        excluded_rule_set {
+          type    = "OWASP"
+          version = "3.2"
 
-        rule_group {
-          rule_group_name = "REQUEST-942-APPLICATION-ATTACK-SQLI"
-          excluded_rules  = ["942440"]
-        }
-      }
-    }
+          rule_group {
+            rule_group_name = "REQUEST-941-APPLICATION-ATTACK-XSS"
+          }
 
-    exclusion {
-      match_variable          = "RequestArgValues"
-      selector                = "note[title]"
-      selector_match_operator = "Equals"
-
-      excluded_rule_set {
-        type    = "OWASP"
-        version = "3.2"
-
-        rule_group {
-          rule_group_name = "REQUEST-942-APPLICATION-ATTACK-SQLI"
-          excluded_rules  = ["942440"]
-        }
-      }
-    }
-
-    # Additional confirmed request parameters used in learning and feedback flows.
-    exclusion {
-      match_variable          = "RequestArgValues"
-      selector                = "response[text_input]"
-      selector_match_operator = "Equals"
-
-      excluded_rule_set {
-        type    = "OWASP"
-        version = "3.2"
-
-        rule_group {
-          rule_group_name = "REQUEST-942-APPLICATION-ATTACK-SQLI"
-          excluded_rules  = ["942440"]
+          rule_group {
+            rule_group_name = "REQUEST-942-APPLICATION-ATTACK-SQLI"
+          }
         }
       }
     }


### PR DESCRIPTION
Diagnosed as WAF (App Gateway) 403s on free-text form fields, not app errors.

WAF (appgateway.tf):
- Replace the narrow per-arg exclusions that only disabled SQLi rule 942440 with a dynamic block over a local.waf_free_text_args list, excluding the whole XSS (941) and SQLi (942) rule groups for each prose field.
- Cover previously-unexcluded user free-text: user[first_name], user[last_name], user[setting_type_other], user[role_type_other], user[closed_reason_custom].

NotesController:
- create now assigns attrs to an existing note (update) instead of saving it unchanged, so re-saving a page no longer silently discards edits.
- tracking_properties guards against a nil body (.to_s.length) to avoid a 500.