### PR TITLE
EYCDTK-1253-0%-assessments

### DIFF
--- a/terraform-azure/terraform-azure-web/appgateway.tf
+++ b/terraform-azure/terraform-azure-web/appgateway.tf
@@ -12,11 +12,15 @@ locals {
     "note[body]",                 # learning log
     "note[title]",                # server-set, but kept for parity
     "response[text_input]",       # feedback / question free text
+    "response[answers]",          # summative / formative question answers (may be free text)
+    "response[submission_nonce]", # UUID anti-replay token; never free text but avoid name-match rules
     "user[first_name]",           # registration — apostrophe surnames
     "user[last_name]",            # registration — apostrophe surnames
     "user[setting_type_other]",   # registration — custom setting
     "user[role_type_other]",      # registration — custom role
     "user[closed_reason_custom]", # account closure reason
+    "authenticity_token",         # Rails CSRF token (server-validated)
+    "_method",                    # Rails method override (server-validated)
   ]
 }
 


### PR DESCRIPTION
Add additional free-text fields to WAF exclusion list for improved handling of assessments. 

Users with the 0% bug consistently have a record created but with a score of 'null' in the db. 

I hypothesise that:
In affected sessions, user answer submissions did not always reach Rails.
The assessment row could exist but remain ungraded, indicating ResponsesController#update for final question submission never executed.
This produced inconsistent test state and “retake” behaviour that appeared to discard or not persist answer changes.

Azure WAF (Prevention mode) was inspecting request args and intermittently blocking valid PATCH form submissions in assessment/response flows.
Existing exclusions covered some prose fields but not all response payload keys used by the questionnaire form.